### PR TITLE
Collapse SongFrame with a button

### DIFF
--- a/src/components/media/SongFrame.vue
+++ b/src/components/media/SongFrame.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- Purpose of Component: to contain a youtube video, load it and handle several actions -->
-    <div class="song-player-container">
+    <div class="song-player-container" :class="{'song-player-container-hidden':$store.state.music.isMinimized}">
         <div class="song-player">
             <youtube
                 :key="'ytplayer' + videoId"

--- a/src/components/nav/MusicBar2.vue
+++ b/src/components/nav/MusicBar2.vue
@@ -81,6 +81,10 @@
                     >
                 </v-slide-x-transition>
                 <div v-if="$vuetify.breakpoint.xs">
+                    <v-btn icon @click="$store.commit('music/minimizePlayer')">
+                        <v-icon v-if="!$store.state.music.isMinimized">{{ icons.mdiChevronDown }}</v-icon>
+                        <v-icon v-else>{{ icons.mdiChevronUp }}</v-icon>
+                    </v-btn>
                     <v-btn icon @click="closePlayer">
                         <v-icon>{{ icons.mdiClose }}</v-icon>
                     </v-btn>
@@ -145,6 +149,10 @@
             </transition>
             <!-- </> -->
             <div class="playlist-buttons align-self-center" v-if="$vuetify.breakpoint.smAndUp">
+                <v-btn icon large @click="$store.commit('music/minimizePlayer')">
+                    <v-icon v-if="!$store.state.music.isMinimized">{{ icons.mdiChevronDown }}</v-icon>
+                    <v-icon v-else>{{ icons.mdiChevronUp }}</v-icon>
+                </v-btn>
                 <v-btn icon large @click="closePlayer">
                     <v-icon>{{ icons.mdiClose }}</v-icon>
                 </v-btn>
@@ -184,6 +192,12 @@
         padding: 2px;
         bottom: 100%;
         right: 0;
+        opacity: 100%;
+        transition-duration: 500ms;
+    }
+    .song-player-container-hidden {
+        bottom: -350%;
+        opacity: 0%;
     }
 }
 
@@ -257,6 +271,8 @@ import {
     mdiRepeatOnce,
     mdiMicrophoneVariant,
     mdiPlaylistRemove,
+    mdiChevronDown,
+    mdiChevronUp,
 } from "@mdi/js";
 
 import SongFrame from "../media/SongFrame.vue";
@@ -287,6 +303,8 @@ export default {
             mdiMicrophoneVariant,
             mdiSkipPrevious,
             mdiPlaylistRemove,
+            mdiChevronDown,
+            mdiChevronUp,
 
             progress: 0,
             player: null,

--- a/src/store/music.module.js
+++ b/src/store/music.module.js
@@ -9,6 +9,7 @@ const initialState = {
     state: MUSIC_PLAYER_STATE.PAUSED,
     mode: MUSIC_PLAYBACK_MODE.LOOP,
 
+    isMinimized: false,
     isOpen: false,
     addedAnimation: false, // state keeping for bouncing the icon.
 };
@@ -184,6 +185,9 @@ const mutations = {
         state.state = MUSIC_PLAYER_STATE.PAUSED;
         state.isOpen = false;
         state.playId += 1;
+    },
+    minimizePlayer(state){
+        state.isMinimized = !state.isMinimized;
     },
 };
 


### PR DESCRIPTION
SongFrame on mobile devices is taking up too much space
<img src="https://user-images.githubusercontent.com/49831545/122246043-e675d980-cece-11eb-80ee-8ac6f5f2585b.png" height="300px"> <img src="https://user-images.githubusercontent.com/49831545/122246058-ea096080-cece-11eb-9afa-86f04db13d75.png" height="300px">
(its chrome dev tools mobile but trust me it takes a lot of space on my phone too)

but now you can collapse the SongFrame using the down button next to the close button!
<img src="https://user-images.githubusercontent.com/49831545/122248613-dbbc4400-ced0-11eb-98cb-4240f6a90e19.png"> <img src="https://user-images.githubusercontent.com/49831545/122249106-3d7cae00-ced1-11eb-91e4-59bb75023143.png">


Tho the button gets squashed on top of the close button when there is not enough space and i don't know how to fix it so it would be cool if someone fixed that
<img src="https://user-images.githubusercontent.com/49831545/122248159-8da74080-ced0-11eb-8eb9-0fdea2d1eecf.png" height="">
