### PR TITLE
Add setting to hide topics from video feeds

### DIFF
--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -146,17 +146,21 @@ export default {
         },
         processedVideos() {
             const blockedChannels = this.$store.getters["settings/blockedChannelIDs"];
+            const hiddenTopics = this.$store.getters["settings/hiddenTopics"];
+            const filterVideos: any = (x) => {
+                return (
+                    (this.ignoreBlock || !blockedChannels.has(x.channel_id || x.channel.id)) &&
+                    !hiddenTopics.has(x.topic_id)
+                );
+            };
+
             if (this.limitRows <= 0 || this.expanded) {
-                return this.videos.filter((x) => {
-                    return this.ignoreBlock || !blockedChannels.has(x.channel_id || x.channel.id);
-                });
+                return this.videos.filter(filterVideos);
             }
             return this.videos
                 .slice(0)
                 .splice(0, this.limitRows * this.colSize)
-                .filter((x) => {
-                    return this.ignoreBlock || !blockedChannels.has(x.channel_id || x.channel.id);
-                });
+                .filter(filterVideos);
         },
         colSize() {
             if (this.horizontal) return 1;

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -129,6 +129,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        hideIgnoredTopics: {
+            type: Boolean,
+            default: false,
+        },
     },
     methods: {
         handleVideoClick(video) {
@@ -150,7 +154,7 @@ export default {
         },
         processedVideos() {
             const blockedChannels = this.$store.getters["settings/blockedChannelIDs"];
-            const hiddenTopics = this.$store.getters["settings/hiddenTopics"];
+            const ignoredTopics = this.$store.getters["settings/ignoredTopics"];
             const favoriteChannels = this.$store.getters["favorites/favoriteChannelIDs"];
 
             const filterVideos = (v) => {
@@ -165,7 +169,9 @@ export default {
                     keep &&= favoriteChannels.has(channelId);
                 }
 
-                keep &&= !hiddenTopics.has(v.topic_id);
+                if (this.hideIgnoredTopics) {
+                    keep &&= !ignoredTopics.has(v.topic_id);
+                }
 
                 return keep;
             };

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -125,6 +125,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        hideCollabs: {
+            type: Boolean,
+            default: false,
+        },
     },
     methods: {
         handleVideoClick(video) {
@@ -147,11 +151,23 @@ export default {
         processedVideos() {
             const blockedChannels = this.$store.getters["settings/blockedChannelIDs"];
             const hiddenTopics = this.$store.getters["settings/hiddenTopics"];
-            const filterVideos: any = (x) => {
-                return (
-                    (this.ignoreBlock || !blockedChannels.has(x.channel_id || x.channel.id)) &&
-                    !hiddenTopics.has(x.topic_id)
-                );
+            const favoriteChannels = this.$store.getters["favorites/favoriteChannelIDs"];
+
+            const filterVideos = (v) => {
+                let keep = true;
+                const channelId = v.channel_id || v.channel.id;
+
+                if (!this.ignoreBlock) {
+                    keep &&= !blockedChannels.has(channelId);
+                }
+
+                if (this.hideCollabs) {
+                    keep &&= favoriteChannels.has(channelId);
+                }
+
+                keep &&= !hiddenTopics.has(v.topic_id);
+
+                return keep;
             };
 
             if (this.limitRows <= 0 || this.expanded) {

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -253,6 +253,8 @@ views:
       - Small
     hideCollabStreamsLabel: Hide Collab Streams
     hideCollabStreamsMsg: Hide collab streams from your favorites feed
+    hideTopicsLabel: Hide Topics
+    hideTopicsMsg: Hide videos with these topics from all video feeds
     theme: Theme
   app:
     update_available: An update is available

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -253,8 +253,8 @@ views:
       - Small
     hideCollabStreamsLabel: Hide Collab Streams
     hideCollabStreamsMsg: Hide collab streams from your favorites feed
-    hideTopicsLabel: Hide Topics
-    hideTopicsMsg: Hide videos with these topics from all video feeds
+    ignoredTopicsLabel: Ignored Topics
+    ignoredTopicsMsg: Hide videos with these topics from the Home and Favorites pages
     theme: Theme
   app:
     update_available: An update is available

--- a/src/store/favorites.module.js
+++ b/src/store/favorites.module.js
@@ -57,11 +57,14 @@ const actions = {
             return api
                 .favoritesLive(rootState.userdata.jwt)
                 .then((res) => {
-                    // filter out collab channels if settings is set
                     let live = res;
+                    // filter out collab channels if settings is set
                     if (rootState.settings.hideCollabStreams) {
                         const favoritesSet = new Set(state.favorites.map((f) => f.id));
-                        live = res.filter((video) => favoritesSet.has(video.channel.id));
+                        live = live.filter((video) => favoritesSet.has(video.channel.id));
+                    }
+                    if (rootState.settings.hiddenTopics) {
+                        live = live.filter((video) => !rootState.settings.hiddenTopics.includes(video.topic_id));
                     }
                     live.sort((a, b) => {
                         if (a.available_at === b.available_at) {

--- a/src/store/favorites.module.js
+++ b/src/store/favorites.module.js
@@ -30,6 +30,9 @@ const getters = {
             (state.favorites.find((f) => f.id === channelId) && state.stagedFavorites[channelId] !== "remove")
         );
     },
+    favoriteChannelIDs: (state) => {
+        return new Set(state.favorites.map((f) => f.id));
+    },
 };
 
 const actions = {
@@ -57,13 +60,7 @@ const actions = {
             return api
                 .favoritesLive(rootState.userdata.jwt)
                 .then((res) => {
-                    // filter out collab channels if settings is set
-                    let live = res;
-                    if (rootState.settings.hideCollabStreams) {
-                        const favoritesSet = new Set(state.favorites.map((f) => f.id));
-                        live = res.filter((video) => favoritesSet.has(video.channel.id));
-                    }
-                    live.sort((a, b) => {
+                    res.sort((a, b) => {
                         if (a.available_at === b.available_at) {
                             return a.id - b.id;
                         }
@@ -71,7 +68,7 @@ const actions = {
                         const dateB = new Date(b.available_at).getTime();
                         return dateA - dateB;
                     });
-                    commit("setLive", live);
+                    commit("setLive", res);
                     commit("fetchEnd");
                 })
                 .catch((e) => {

--- a/src/store/favorites.module.js
+++ b/src/store/favorites.module.js
@@ -57,14 +57,11 @@ const actions = {
             return api
                 .favoritesLive(rootState.userdata.jwt)
                 .then((res) => {
-                    let live = res;
                     // filter out collab channels if settings is set
+                    let live = res;
                     if (rootState.settings.hideCollabStreams) {
                         const favoritesSet = new Set(state.favorites.map((f) => f.id));
-                        live = live.filter((video) => favoritesSet.has(video.channel.id));
-                    }
-                    if (rootState.settings.hiddenTopics) {
-                        live = live.filter((video) => !rootState.settings.hiddenTopics.includes(video.topic_id));
+                        live = res.filter((video) => favoritesSet.has(video.channel.id));
                     }
                     live.sort((a, b) => {
                         if (a.available_at === b.available_at) {

--- a/src/store/home.module.js
+++ b/src/store/home.module.js
@@ -35,7 +35,11 @@ const actions = {
                     include: "mentions",
                 })
                 .then((res) => {
-                    commit("setLive", res);
+                    let live = res;
+                    if (rootState.settings.hiddenTopics) {
+                        live = live.filter((video) => !rootState.settings.hiddenTopics.includes(video.topic_id));
+                    }
+                    commit("setLive", live);
                     commit("fetchEnd");
                 })
                 .catch((e) => {

--- a/src/store/home.module.js
+++ b/src/store/home.module.js
@@ -35,11 +35,7 @@ const actions = {
                     include: "mentions",
                 })
                 .then((res) => {
-                    let live = res;
-                    if (rootState.settings.hiddenTopics) {
-                        live = live.filter((video) => !rootState.settings.hiddenTopics.includes(video.topic_id));
-                    }
-                    commit("setLive", live);
+                    commit("setLive", res);
                     commit("fetchEnd");
                 })
                 .catch((e) => {

--- a/src/store/settings.module.js
+++ b/src/store/settings.module.js
@@ -23,7 +23,7 @@ const initialState = {
     hideThumbnail: false,
     nameProperty: englishNamePrefs.has(lang) ? "english_name" : "name",
     hideCollabStreams: false,
-    hiddenTopics: [],
+    ignoredTopics: [],
 
     // Live TL Window Settings
     liveTlStickBottom: false,
@@ -53,8 +53,8 @@ const getters = {
     liveTlBlockedNames(state) {
         return new Set(state.liveTlBlocked);
     },
-    hiddenTopics(state) {
-        return new Set(state.hiddenTopics);
+    ignoredTopics(state) {
+        return new Set(state.ignoredTopics);
     },
 };
 
@@ -89,8 +89,8 @@ const mutations = {
     setClipLangs(state, val) {
         state.clipLangs = val;
     },
-    setHiddenTopics(state, val) {
-        state.hiddenTopics = val;
+    setIgnoredTopics(state, val) {
+        state.ignoredTopics = val;
     },
     setScrollMode(state, val) {
         state.scrollMode = val;
@@ -104,7 +104,7 @@ const mutations = {
         "liveTlShowModerator",
         "liveTlWindowSize",
         "hideCollabStreams",
-        "hiddenTopics",
+        "ignoredTopics",
     ]),
     resetState(state) {
         Object.assign(state, initialState);

--- a/src/store/settings.module.js
+++ b/src/store/settings.module.js
@@ -23,6 +23,7 @@ const initialState = {
     hideThumbnail: false,
     nameProperty: englishNamePrefs.has(lang) ? "english_name" : "name",
     hideCollabStreams: false,
+    hiddenTopics: [],
 
     // Live TL Window Settings
     liveTlStickBottom: false,
@@ -51,6 +52,9 @@ const getters = {
     },
     liveTlBlockedNames(state) {
         return new Set(state.liveTlBlocked);
+    },
+    hiddenTopics(state) {
+        return new Set(state.hiddenTopics);
     },
 };
 
@@ -84,6 +88,9 @@ const mutations = {
     },
     setClipLangs(state, val) {
         state.clipLangs = val;
+    },
+    setHiddenTopics(state, val) {
+        state.hiddenTopics = val;
     },
     setScrollMode(state, val) {
         state.scrollMode = val;

--- a/src/store/settings.module.js
+++ b/src/store/settings.module.js
@@ -104,6 +104,7 @@ const mutations = {
         "liveTlShowModerator",
         "liveTlWindowSize",
         "hideCollabStreams",
+        "hiddenTopics",
     ]),
     resetState(state) {
         Object.assign(state, initialState);

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -274,18 +274,6 @@ export default {
                         limit,
                         offset,
                     })
-                    .then((apiRes) => {
-                        if (this.$store.state.settings.hideCollabStreams) {
-                            const favoritesSet = new Set(this.$store.state.favorites.map((f) => f.id));
-                            apiRes.data.items = apiRes.data.items.filter((v) => favoritesSet.has(v.channel.id));
-                        }
-                        if (this.$store.state.settings.hiddenTopics) {
-                            apiRes.data.items = apiRes.data.items.filter(
-                                (v) => !this.$store.state.settings.hiddenTopics.includes(v.topic_id),
-                            );
-                        }
-                        return apiRes;
-                    })
                     .catch((err) => {
                         console.error(err);
                         this.$store.dispatch("loginVerify"); // check if the user is actually logged in.

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -58,6 +58,7 @@
                             :cols="colSizes"
                             :dense="currentGridSize > 0"
                             :hideCollabs="shouldHideCollabs"
+                            hideIgnoredTopics
                         >
                         </VideoCardList>
                         <v-divider class="my-3 secondary" v-if="lives.length" />
@@ -68,6 +69,7 @@
                             :cols="colSizes"
                             :dense="currentGridSize > 0"
                             :hideCollabs="shouldHideCollabs"
+                            hideIgnoredTopics
                         >
                         </VideoCardList>
                     </template>
@@ -95,6 +97,7 @@
                                 :cols="colSizes"
                                 :dense="currentGridSize > 0"
                                 :hideCollabs="shouldHideCollabs"
+                                hideIgnoredTopics
                             />
                             <!-- only show SkeletonCardList if it's loading -->
                             <SkeletonCardList v-if="isLoading" :cols="colSizes" :dense="currentGridSize > 0" />

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -274,6 +274,14 @@ export default {
                         limit,
                         offset,
                     })
+                    .then((apiRes) => {
+                        if (this.$store.state.settings.hiddenTopics) {
+                            apiRes.data.items = apiRes.data.items.filter(
+                                (v) => !this.$store.state.settings.hiddenTopics.includes(v.topic_id),
+                            );
+                        }
+                        return apiRes;
+                    })
                     .catch((err) => {
                         console.error(err);
                         this.$store.dispatch("loginVerify"); // check if the user is actually logged in.

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -275,6 +275,10 @@ export default {
                         offset,
                     })
                     .then((apiRes) => {
+                        if (this.$store.state.settings.hideCollabStreams) {
+                            const favoritesSet = new Set(this.$store.state.favorites.map((f) => f.id));
+                            apiRes.data.items = apiRes.data.items.filter((v) => favoritesSet.has(v.channel.id));
+                        }
                         if (this.$store.state.settings.hiddenTopics) {
                             apiRes.data.items = apiRes.data.items.filter(
                                 (v) => !this.$store.state.settings.hiddenTopics.includes(v.topic_id),

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -57,6 +57,7 @@
                             :includeAvatar="shouldIncludeAvatar"
                             :cols="colSizes"
                             :dense="currentGridSize > 0"
+                            :hideCollabs="shouldHideCollabs"
                         >
                         </VideoCardList>
                         <v-divider class="my-3 secondary" v-if="lives.length" />
@@ -66,6 +67,7 @@
                             :includeAvatar="shouldIncludeAvatar"
                             :cols="colSizes"
                             :dense="currentGridSize > 0"
+                            :hideCollabs="shouldHideCollabs"
                         >
                         </VideoCardList>
                     </template>
@@ -92,6 +94,7 @@
                                 includeChannel
                                 :cols="colSizes"
                                 :dense="currentGridSize > 0"
+                                :hideCollabs="shouldHideCollabs"
                             />
                             <!-- only show SkeletonCardList if it's loading -->
                             <SkeletonCardList v-if="isLoading" :cols="colSizes" :dense="currentGridSize > 0" />
@@ -207,6 +210,9 @@ export default {
             if (this.$vuetify.breakpoint.sm && this.currentGridSize > 0) return false;
             if (this.$vuetify.breakpoint.xs && this.currentGridSize > 0) return false;
             return true;
+        },
+        shouldHideCollabs() {
+            return this.$store.state.settings.hideCollabStreams;
         },
         lives() {
             return this.live.filter((v) => v.status === "live");

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -54,6 +54,7 @@
                         :includeAvatar="shouldIncludeAvatar"
                         :cols="colSizes"
                         :dense="currentGridSize > 0"
+                        hideIgnoredTopics
                     >
                     </VideoCardList>
                     <v-divider class="my-3 secondary" v-if="lives.length" />
@@ -63,6 +64,7 @@
                         :includeAvatar="shouldIncludeAvatar"
                         :cols="colSizes"
                         :dense="currentGridSize > 0"
+                        hideIgnoredTopics
                     >
                     </VideoCardList>
                 </template>
@@ -89,6 +91,7 @@
                             includeChannel
                             :cols="colSizes"
                             :dense="currentGridSize > 0"
+                            hideIgnoredTopics
                         />
                         <!-- only show SkeletonCardList if it's loading -->
                         <SkeletonCardList v-if="isLoading" :cols="colSizes" :dense="currentGridSize > 0" />

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -263,16 +263,25 @@ export default {
         },
         getLoadFn() {
             return async (offset, limit) => {
-                const res = await backendApi.videos({
-                    status: "past",
-                    ...{ type: this.tab === this.Tabs.ARCHIVE ? "stream" : "clip" },
-                    include: "clips",
-                    org: this.$store.state.currentOrg.name,
-                    lang: this.$store.state.settings.clipLangs.join(","),
-                    paginated: !this.scrollMode,
-                    limit,
-                    offset,
-                });
+                const res = await backendApi
+                    .videos({
+                        status: "past",
+                        ...{ type: this.tab === this.Tabs.ARCHIVE ? "stream" : "clip" },
+                        include: "clips",
+                        org: this.$store.state.currentOrg.name,
+                        lang: this.$store.state.settings.clipLangs.join(","),
+                        paginated: !this.scrollMode,
+                        limit,
+                        offset,
+                    })
+                    .then((apiRes) => {
+                        if (this.$store.state.settings.hiddenTopics) {
+                            apiRes.data.items = apiRes.data.items.filter(
+                                (v) => !this.$store.state.settings.hiddenTopics.includes(v.topic_id),
+                            );
+                        }
+                        return apiRes;
+                    });
                 return res.data;
             };
         },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -263,25 +263,16 @@ export default {
         },
         getLoadFn() {
             return async (offset, limit) => {
-                const res = await backendApi
-                    .videos({
-                        status: "past",
-                        ...{ type: this.tab === this.Tabs.ARCHIVE ? "stream" : "clip" },
-                        include: "clips",
-                        org: this.$store.state.currentOrg.name,
-                        lang: this.$store.state.settings.clipLangs.join(","),
-                        paginated: !this.scrollMode,
-                        limit,
-                        offset,
-                    })
-                    .then((apiRes) => {
-                        if (this.$store.state.settings.hiddenTopics) {
-                            apiRes.data.items = apiRes.data.items.filter(
-                                (v) => !this.$store.state.settings.hiddenTopics.includes(v.topic_id),
-                            );
-                        }
-                        return apiRes;
-                    });
+                const res = await backendApi.videos({
+                    status: "past",
+                    ...{ type: this.tab === this.Tabs.ARCHIVE ? "stream" : "clip" },
+                    include: "clips",
+                    org: this.$store.state.currentOrg.name,
+                    lang: this.$store.state.settings.clipLangs.join(","),
+                    paginated: !this.scrollMode,
+                    limit,
+                    offset,
+                });
                 return res.data;
             };
         },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -111,6 +111,24 @@
                         :label="$t('views.settings.hideCollabStreamsLabel')"
                         :messages="$t('views.settings.hideCollabStreamsMsg')"
                     ></v-switch>
+
+                    <v-divider class="my-2" />
+
+                    <v-autocomplete
+                        v-model="hiddenTopics"
+                        :items="topics"
+                        multiple
+                        chips
+                        clearable
+                        deletable-chips
+                        :label="$t('views.settings.hideTopicsLabel')"
+                        :hint="$t('views.settings.hideTopicsMsg')"
+                        persistent-hint
+                    >
+                    </v-autocomplete>
+
+                    <v-divider class="my-2" />
+
                     <v-switch
                         v-model="useEnName"
                         :label="$t('views.settings.useEnglishNameLabel')"
@@ -138,6 +156,7 @@ import { TL_LANGS } from "@/utils/consts";
 import themeSet from "@/utils/themes";
 import { syncState } from "@/utils/functions";
 import Vue from "vue";
+import backendApi from "@/utils/backend-api";
 
 export default {
     name: "Settings",
@@ -155,6 +174,11 @@ export default {
             default: false,
         },
     },
+    async mounted() {
+        backendApi.topics().then(({ data }) => {
+            this.topics = data.map(({ id, count }) => ({ value: id, text: `${id} (${count})` }));
+        });
+    },
     computed: {
         ...syncState("settings", [
             "darkMode",
@@ -164,6 +188,7 @@ export default {
             "hideThumbnail",
             "defaultOpen",
             "hideCollabStreams",
+            "hiddenTopics",
         ]),
         currentGridSize: {
             get() {
@@ -196,6 +221,14 @@ export default {
             set(val: any[]) {
                 // sort array to increase cache hit rate
                 this.$store.commit("settings/setClipLangs", val.sort());
+            },
+        },
+        hiddenTopics: {
+            get() {
+                return this.$store.state.settings.hiddenTopics;
+            },
+            set(val: any[]) {
+                this.$store.commit("settings/setHiddenTopics", val.sort());
             },
         },
         theme() {
@@ -243,6 +276,7 @@ export default {
                     value: "multiview",
                 },
             ]),
+            topics: [],
         };
     },
     methods: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -115,14 +115,14 @@
                     <v-divider class="my-2" />
 
                     <v-autocomplete
-                        v-model="hiddenTopics"
+                        v-model="ignoredTopics"
                         :items="topics"
                         multiple
                         chips
                         clearable
                         deletable-chips
-                        :label="$t('views.settings.hideTopicsLabel')"
-                        :hint="$t('views.settings.hideTopicsMsg')"
+                        :label="$t('views.settings.ignoredTopicsLabel')"
+                        :hint="$t('views.settings.ignoredTopicsMsg')"
                         persistent-hint
                     >
                     </v-autocomplete>
@@ -188,7 +188,7 @@ export default {
             "hideThumbnail",
             "defaultOpen",
             "hideCollabStreams",
-            "hiddenTopics",
+            "ignoredTopics",
         ]),
         currentGridSize: {
             get() {
@@ -223,12 +223,12 @@ export default {
                 this.$store.commit("settings/setClipLangs", val.sort());
             },
         },
-        hiddenTopics: {
+        ignoredTopics: {
             get() {
-                return this.$store.state.settings.hiddenTopics;
+                return this.$store.state.settings.ignoredTopics;
             },
             set(val: any[]) {
-                this.$store.commit("settings/setHiddenTopics", val.sort());
+                this.$store.commit("settings/setIgnoredTopics", val.sort());
             },
         },
         theme() {


### PR DESCRIPTION
Add a setting to hide topics from video feeds. Videos with matching topics are hidden from the Live and Archive views of the Home and Favorites pages.

Move the "hide collabs" filter into the VideoCardList component, which makes it work on the Archive view of the Favorites page.

This is my first time working with Vue and my first time in a while doing any web frontend work, so please let me know if you'd like me to change how I implemented anything.

Closes #271.