### PR TITLE
fix: move api switch to devserver proxy

### DIFF
--- a/.env.placeholder
+++ b/.env.placeholder
@@ -1,0 +1,3 @@
+# Uncomment this if you want api requests to be routed to a local api server
+# API_BASE_URL=http://localhost:2434
+# REWRITE_API_PATH=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 node_modules
 /dist
-
+.env
 
 # local env files
 .env.local

--- a/src/components/chat/LiveTranslations.vue
+++ b/src/components/chat/LiveTranslations.vue
@@ -105,7 +105,7 @@ import Vue from "vue";
 import WatchLiveTranslationsSetting from "./LiveTranslationsSetting.vue";
 import chatMixin from "./chatMixin";
 
-const manager = new Manager(/* process.env.NODE_ENV === "development" ? "http://localhost:2434" : */ API_BASE_URL, {
+const manager = new Manager(API_BASE_URL, {
     reconnectionAttempts: 10,
     transports: ["websocket"],
     upgrade: false,

--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -4,12 +4,8 @@ import querystring from "querystring";
 import { CHANNEL_URL_REGEX, VIDEO_URL_REGEX } from "./consts";
 import { Playlist, PlaylistList } from "./types";
 
-export const API_BASE_URL =
-    process.env.NODE_ENV === "development" ? "https://staging.holodex.net/api" : `${window.location.origin}/api`;
-export const SITE_BASE_URL =
-    process.env.NODE_ENV === "development" ? "https://staging.holodex.net/" : `${window.location.origin}/`;
-
-// export const API_BASE_URL = "http://localhost:2434";
+export const API_BASE_URL = `${window.location.origin}/api`;
+export const SITE_BASE_URL = `${window.location.origin}/`;
 
 export const axiosInstance = (() => {
     const instance = axios.create({ baseURL: `${API_BASE_URL}/v2` });

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -100,7 +100,7 @@ const gauthOption = {
 };
 Vue.use(GAuth, gauthOption);
 
-const apiURI = process.env.NODE_ENV === "development" ? "http://localhost:2434" : "/api";
+const apiURI = "/api";
 // the fact this URI is invalid doesn't matter,
 // all it matters is we own the domain so oauth-open can grab the URI from the window
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,20 @@
+const API_BASE_URL = process.env.API_BASE_URL || "https://staging.holodex.net";
+const REWRITE_API_PATH = !!process.env.REWRITE_API_PATH;
+
 module.exports = {
+    devServer: {
+        proxy: {
+            "/api": {
+                target: API_BASE_URL,
+                pathRewrite: REWRITE_API_PATH && { "^/api": "" },
+                secure: false,
+            },
+            "/orgs.json": {
+                target: `${API_BASE_URL}/orgs.json`,
+                secure: false,
+            },
+        },
+    },
     chainWebpack: (config) => {
         // if (process.env.STORYBOOK && process.env.STORYBOOK.trim() === "true") {
         //     console.info("info => Updating webpack using chain-webpack");


### PR DESCRIPTION
`.env` will look like this:
```env
# Uncomment this if you want api requests to be routed to a local api server
# API_BASE_URL=http://localhost:2434
# REWRITE_API_PATH=true
```