### PR TITLE
Fix VideoCard preview in multiview for short title

### DIFF
--- a/src/components/multiview/VideoSelector.vue
+++ b/src/components/multiview/VideoSelector.vue
@@ -200,7 +200,7 @@
           :video="video"
           disable-default-click
           include-channel
-          style="max-width: 250px"
+          style="width: 250px"
         />
       </v-tooltip>
     </template>


### PR DESCRIPTION
This PR fixes an issue where if the content of a video card preview in multiview does not fill the entire card, the preview will be too small and the duration/tags may incorrectly render over other parts of the card. This is a rare case that occurs when there are no viewer counts next to the "Live Now" text with a short title which causes the video card to be too short in width. See:

![image](https://user-images.githubusercontent.com/8785414/128224099-843e17c1-1644-4d68-8cc9-f440b75286c7.png)

Since the max-width is already hardcoded, I opted to just change it from max-width to width. Alternatively, min-width and max-width could be used together.

After using width instead of max-width, you can see that the card will be more consistently sized and not resize to be too small

![image](https://user-images.githubusercontent.com/8785414/128224074-e6bf8a94-7fdb-44ea-bebd-b4fb0390c830.png)