### PR TITLE
Make the sync bar appear even if only 1 archive is active

### DIFF
--- a/src/components/multiview/MultiviewSyncBar.vue
+++ b/src/components/multiview/MultiviewSyncBar.vue
@@ -238,7 +238,7 @@ export default {
             return formatDuration((this.maxTs - this.minTs) * 1000);
         },
         hasVideosToSync() {
-            return this.overlapVideos.length > 1;
+            return this.overlapVideos.length >= 1;
         },
         routeCurrentTs() {
             return this.$route.query.t;


### PR DESCRIPTION
This implements what was requested in #473:

> Early versions of archive sync on the Staging site allowed for the 'syncing' of a single archive. This had the helpful benefit skipping through an archived stream based on local time rather than time in the archive.

Minimal changes to the code was applied (1 line only lmao). It should be noted though that the i18n string for `views.multiview.sync.nothingToSync` probably needs to be changed from _"Nothing to sync, please open two overlapping archives (eg. collab streams)"_ to a more fitting text since we don't really require at least two archives now.

I have to say though: this change makes it look like that the requested functionality is something like a hidden feature. As a regular user, I wouldn't expect the archive sync to do that.

Closes #473 