### PR TITLE
[fix:#531] truncate div.video-topic to fit thumbnail width

### DIFF
--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -699,6 +699,9 @@ export default {
   font-size: 0.8125rem;
   letter-spacing: 0.025em;
   text-transform: capitalize;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .video-card-action {


### PR DESCRIPTION
added simple css attributes to hide overflowing texts and replace with ellipsis.