### PR TITLE
Relay bot setting page

### DIFF
--- a/src/components/nav/MainNav.vue
+++ b/src/components/nav/MainNav.vue
@@ -2,7 +2,13 @@
   <div>
     <!-- watch page nav drawer is temporary, but causes layout shifting from hiding/unhiding -->
     <!-- create two different instances as a work around -->
-    <NavDrawer v-model="navDrawer" :pages="pages" :temporary="isMobile || isWatchPage">
+    <NavDrawer
+      v-model="navDrawer"
+      :pages="pages"
+      :temporary="isMobile || isWatchPage"
+      :expand="navbarExpanded"
+      @expand="navbarExpanded = !navbarExpanded"
+    >
       <!-- <NavDrawer :pages="pages" v-model="drawer2" v-if="isMobile || isWatchPage"  -->
       <template v-if="isMobile">
         <!-- <InstallPrompt /> -->
@@ -34,7 +40,7 @@
       <template v-if="!isMobile || (isMobile && !searchBarExpanded)">
         <!--================= Logo & Search Bar (Space permitting) ================-->
 
-        <v-app-bar-nav-icon @click.stop="navDrawer = !navDrawer">
+        <v-app-bar-nav-icon @click.stop="navDrawer = !navDrawer; navbarExpanded = false">
           <v-icon>{{ icons.mdiMenu }}</v-icon>
         </v-app-bar-nav-icon>
         <v-toolbar-title style="overflow: visible" :class="{ 'pa-0': isMobile }">
@@ -187,6 +193,7 @@ export default {
         return {
             favoritesExpanded: false,
             searchBarExpanded: false,
+            navbarExpanded: false,
         };
     },
     computed: {
@@ -240,12 +247,6 @@ export default {
                     collapsible: true,
                 },
                 {
-                    name: "Script Manager",
-                    path: "/scriptmanager",
-                    icon: this.icons.mdiFileDocumentMultiple,
-                    collapsible: true,
-                },
-                {
                     name: "Musicdex",
                     path: musicdexURL,
                     // icon: this.icons.mdiMusic,
@@ -263,6 +264,34 @@ export default {
                     path: "/settings",
                     icon: this.icons.mdiCog,
                     collapsible: true,
+                },
+                {
+                    name: "TL client",
+                    path: "/tlclient",
+                    icon: this.icons.mdiTypewriter,
+                    collapsible: true,
+                    extra: true,
+                },
+                {
+                    name: "Script Editor",
+                    path: "/scripteditor",
+                    icon: this.icons.mdiNoteEdit,
+                    collapsible: true,
+                    extra: true,
+                },
+                {
+                    name: "Script Manager",
+                    path: "/scriptmanager",
+                    icon: this.icons.mdiFileDocumentMultiple,
+                    collapsible: true,
+                    extra: true,
+                },
+                {
+                    name: "Relay Bot Setting",
+                    path: "/relaybot",
+                    icon: this.icons.mdiRobot,
+                    collapsible: true,
+                    extra: true,
                 },
             ];
         },

--- a/src/components/nav/NavDrawer.vue
+++ b/src/components/nav/NavDrawer.vue
@@ -12,7 +12,7 @@
     <slot />
     <v-list dense class="pb-0">
       <!-- <v-list> -->
-      <template v-for="page in pages">
+      <template v-for="page in pages.filter(e => !e.extra)">
         <v-list-item
           :key="page.name"
           link
@@ -51,9 +51,38 @@
         </v-list-item>
         <v-divider v-if="page.divider" :key="`${page.path}-divider`" />
       </template>
+      <!-- Expanded part -->
+      <v-divider v-if="expand" />
+
+      <template v-if="expand">
+        <v-list-item
+          v-for="page in pages.filter(e => e.extra)"
+          :key="page.name"
+          link
+          :href="page.path"
+          :class="{ 'v-list-item--active': $route.fullPath === page.path }"
+          @click="(e) => handlePageClick(page, e)"
+        >
+          <v-list-item-icon>
+            <v-icon>{{ page.icon }}</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title v-html="page.name" />
+          </v-list-item-content>
+        </v-list-item>
+      </template>
       <!-- </v-list> -->
     </v-list>
     <v-divider />
+    <div class="d-flex justify-center">
+      <v-btn
+        icon
+        x-small
+        @click="$emit('expand', {});"
+      >
+        <v-icon>{{ expand ? mdiChevronUp : mdiChevronDown }}</v-icon>
+      </v-btn>
+    </div>
     <v-list dense>
       <v-subheader class="pl-5 text-overline">
         {{ $t("component.mainNav.favorites") }}
@@ -121,7 +150,7 @@ import ChannelImg from "@/components/channel/ChannelImg.vue";
 import ChannelInfo from "@/components/channel/ChannelInfo.vue";
 import { langs } from "@/plugins/vuetify";
 import { dayjs, formatDurationShort } from "@/utils/time";
-import { mdiTuneVariant, mdiPatreon } from "@mdi/js";
+import { mdiTuneVariant, mdiPatreon, mdiChevronUp, mdiChevronDown } from "@mdi/js";
 import Settings from "@/views/Settings.vue";
 import MusicdexLogo from "@/components/common/MusicdexLogo.vue";
 
@@ -137,6 +166,10 @@ export default {
         pages: {
             required: true,
             type: Array,
+        },
+        expand: {
+            type: Boolean,
+            default: false,
         },
         value: {
             type: Boolean,
@@ -156,6 +189,8 @@ export default {
 
             mdiTuneVariant,
             mdiPatreon,
+            mdiChevronDown,
+            mdiChevronUp,
         };
     },
     computed: {
@@ -320,5 +355,15 @@ export default {
 .ch-upcoming {
     font-size: small;
     line-height: 24px;
+}
+.trapezoid {
+  width: 230px;
+  text-align: center;
+  height: 0;
+  position: relative;
+  border-right: 50px solid transparent;
+  border-top: 40px solid #2963BD;
+  border-left: 50px solid transparent;
+  box-sizing: content-box;
 }
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,6 +28,7 @@ const Extension = () => import("../views/Extension.vue");
 const TLClient = () => import("../views/TLClient.vue");
 const TLScriptEditor = () => import("../views/TLScriptEditor.vue");
 const TLManager = () => import("../views/TLScriptManager.vue");
+const RelayBotSetting = () => import("../views/RelayBotSetting.vue");
 
 Vue.use(VueRouter);
 
@@ -172,6 +173,11 @@ const routes = [
         name: "scriptmanager",
         path: "/scriptmanager",
         component: TLManager,
+    },
+    {
+        name: "relaybotsetting",
+        path: "/relaybot",
+        component: RelayBotSetting,
     },
     {
         path: "/404",

--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -385,7 +385,7 @@ export default {
     },
     fetchMChadData(room, pass) {
         return axios.post(
-"https://repo.mchatx.org/HolodexDahcM/",
+            "https://repo.mchatx.org/HolodexDahcM/",
             {
                 Room: room,
                 Pass: pass,
@@ -395,4 +395,34 @@ export default {
     requestChannel(obj) {
         return axiosInstance.post("/reports/channel", obj);
     },
+
+    // ---------- RELAY BOT DISCORD LOGIN ----------
+    relayBotLogin(code, mode) {
+        return axios.post("http://localhost:28282/user", {
+            code,
+            mode,
+        });
+    },
+    relayBotCheckBotPresence(guildAddressList) {
+        return axios.post("http://localhost:28282/guild", {
+            ids: guildAddressList,
+        });
+    },
+    relayBotGetChannels(guildAddress) {
+        return axios.post("http://localhost:28282/channel", {
+            guild: guildAddress,
+        });
+    },
+    relayBotGetSettingChannel(channelAddress) {
+        return axios.post("http://localhost:28282/data", {
+            channel: channelAddress,
+        });
+    },
+    relayBotSubmitData(channelAddress, data) {
+        return axios.post("http://localhost:28282/submit", {
+            Address: channelAddress,
+            SubChannel: data,
+        });
+    },
+    //= ========= RELAY BOT DISCORD LOGIN ==========
 };

--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -398,28 +398,28 @@ export default {
 
     // ---------- RELAY BOT DISCORD LOGIN ----------
     relayBotLogin(code, mode) {
-        return axios.post("http://localhost:28282/user", {
+        return axios.post("https://repo.mchatx.org/holodexproxybot/user", {
             code,
             mode,
         });
     },
     relayBotCheckBotPresence(guildAddressList) {
-        return axios.post("http://localhost:28282/guild", {
+        return axios.post("https://repo.mchatx.org/holodexproxybot/guild", {
             ids: guildAddressList,
         });
     },
     relayBotGetChannels(guildAddress) {
-        return axios.post("http://localhost:28282/channel", {
+        return axios.post("https://repo.mchatx.org/holodexproxybot/channel", {
             guild: guildAddress,
         });
     },
     relayBotGetSettingChannel(channelAddress) {
-        return axios.post("http://localhost:28282/data", {
+        return axios.post("https://repo.mchatx.org/holodexproxybot/data", {
             channel: channelAddress,
         });
     },
     relayBotSubmitData(channelAddress, data) {
-        return axios.post("http://localhost:28282/submit", {
+        return axios.post("https://repo.mchatx.org/holodexproxybot/submit", {
             Address: channelAddress,
             SubChannel: data,
         });

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -63,6 +63,8 @@ export {
     mdiContentSaveEdit,
     mdiPinOutline,
     mdiFileDocumentMultiple,
+    mdiRobot,
+    mdiNoteEdit,
 } from "@mdi/js";
 
 export const ytChat = "M20,2H4C2.9,2,2,2.9,2,4v18l4-4h14c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2zM9.9,10.8v3.8h-2v-3.8L5.1,6.6h2.4l1.4,2.2 l1.4-2.2h2.4L9.9,10.8zM18.9,8.6h-2v6h-2v-6h-2v-2h6V8.6z";

--- a/src/views/RelayBotSetting.vue
+++ b/src/views/RelayBotSetting.vue
@@ -1,0 +1,360 @@
+<template>
+  <v-container fill-height fluid>
+    <v-card
+      v-if="!loggedIn"
+      class="d-flex justify-center"
+      width="100%"
+      height="100%"
+    >
+      <v-btn
+        color="primary"
+        elevation="9"
+        large
+        :href="discordOAuth2Links"
+      >
+        login discord
+      </v-btn>
+    </v-card>
+    <v-card
+      v-if="loggedIn"
+      class="d-flex flex-row"
+      width="100%"
+      height="100%"
+    >
+      <v-card class="d-flex flex-column" style="height: 100%; width:25%;">
+        <v-card-title class="justify-center">
+          Servers
+        </v-card-title>
+        <v-card style="height: 100%; width: 100%; overflow-y:auto">
+          <div class="d-flex flex-column" style="height: 100%: overflow-y:hidden">
+            <v-btn
+              v-for="(guild, index) in guilds"
+              :key="'g' + index"
+              color="primary"
+              style="margin-bottom: 5px"
+              small
+              @click="loadChannel(index);"
+            >
+              {{ guild.name }}
+            </v-btn>
+          </div>
+        </v-card>
+      </v-card>
+      <v-card v-if="selectedGuild !== -1" style="height: 100%; border-left: 10px solid black" :width="guilds[selectedGuild].bot && guilds[selectedGuild].admin ? '25%' : '70%'">
+        <v-card
+          v-if="!guilds[selectedGuild].admin"
+          class="d-flex flex-column"
+          height="100%"
+          width="100%"
+        >
+          <v-card-title style="word-break: break-word" class="justify-center">
+            You don't have enough privilege to set up bot in this server.
+          </v-card-title>
+        </v-card>
+        <v-card
+          v-else-if="!guilds[selectedGuild].bot"
+          class="d-flex flex-column"
+          height="100%"
+          width="100%"
+        >
+          <v-card-title class="justify-center" style="word-break: break-word;">
+            Bot is not in this server.
+          </v-card-title>
+          <v-card class="d-flex justify-center">
+            <v-btn
+              color="primary"
+              elevation="9"
+              large
+              href="https://discord.com/api/oauth2/authorize?client_id=826055534318583858&permissions=274877910016&scope=bot"
+            >
+              Invite Bot
+            </v-btn>
+          </v-card>
+        </v-card>
+        <v-card
+          v-else
+          class="d-flex flex-column"
+          height="100%"
+          width="100%"
+        >
+          <v-card-title class="justify-center" style="word-break: break-word">
+            {{ 'Channels (' + guilds[selectedGuild].name + ')' }}
+          </v-card-title>
+          <v-card style="height: 100%; width: 100%; overflow-y:auto">
+            <div class="d-flex flex-column" style="height: 100%: overflow-y:hidden">
+              <v-btn
+                v-for="(channel, index) in channels"
+                :key="'c' + index"
+                color="primary"
+                style="margin-bottom: 5px"
+                small
+                @click="loadSetting(index);"
+              >
+                {{ channel.name }}
+              </v-btn>
+            </div>
+          </v-card>
+        </v-card>
+      </v-card>
+      <v-card
+        v-if="selectedChannel !== -1"
+        class="d-flex flex-column"
+        style="border-left: 10px solid black"
+        width="50%"
+      >
+        <v-card-title class="justify-center" style="word-break: break-word">
+          {{ 'Setting (' + channels[selectedChannel].name + ')' }}
+        </v-card-title>
+        <v-card-actions>
+          <v-text-field v-model="channelInpt" label="Youtube Channel" />
+        </v-card-actions>
+        <v-card-actions>
+          <v-select
+            v-model="langInpt"
+            :items="TL_LANGS"
+            :item-text="item => item.text + ' (' + item.value + ')'"
+            item-value="value"
+            label="Lang"
+            return-object
+          />
+          <v-btn
+            icon
+            lg
+            @click="addSetting();"
+          >
+            <v-icon>
+              {{ mdiPlusCircle }}
+            </v-icon>
+          </v-btn>
+        </v-card-actions>
+        <v-simple-table
+          fixed-header
+          style="max-height:66vh"
+          width="auto"
+        >
+          <thead>
+            <tr>
+              <th class="text-left" style="width: 70%">
+                Subscribed Channel
+              </th>
+              <th class="text-left" style="width: 25%">
+                Lang
+              </th>
+              <th class="text-left" />
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(set, index) in setting" :key="'s' +index">
+              <td>{{ set.link }}</td>
+              <td>{{ set.lang }}</td>
+              <td>
+                <v-btn
+                  icon
+                  lg
+                  @click="setting.splice(index, 1);"
+                >
+                  <v-icon>
+                    {{ mdiMinusCircle }}
+                  </v-icon>
+                </v-btn>
+              </td>
+            </tr>
+          </tbody>
+        </v-simple-table>
+        <v-card class="d-flex justify-center">
+          <v-card>
+            <v-btn large color="primary" @click="saveSetting();">
+              Save
+            </v-btn>
+            <v-card-subtitle>{{ saveNotif }}</v-card-subtitle>
+          </v-card>
+        </v-card>
+      </v-card>
+    </v-card>
+  </v-container>
+</template>
+
+<script lang="ts">
+import backendApi from "@/utils/backend-api";
+import { TL_LANGS } from "@/utils/consts";
+import { mdiPlusCircle, mdiMinusCircle } from "@mdi/js";
+
+export default {
+    name: "RelayBotSetting",
+    metaInfo() {
+        return {
+            get title() {
+                return "RelayBot - Holodex";
+            },
+        };
+    },
+    data() {
+        return {
+            mdiPlusCircle,
+            mdiMinusCircle,
+            TL_LANGS,
+            loggedIn: false,
+            accessToken: "",
+            guilds: [],
+            channels: [],
+            setting: [],
+            channelInpt: "",
+            langInpt: TL_LANGS[0],
+            selectedGuild: -1,
+            selectedChannel: -1,
+            saveNotif: "",
+        };
+    },
+    computed: {
+        discordOAuth2Links() {
+            // eslint-disable-next-line no-restricted-globals
+            switch (location.hostname) {
+                case "localhost": return ("https://discord.com/api/oauth2/authorize?client_id=826055534318583858&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Frelaybot&response_type=code&scope=guilds%20identify");
+                case "staging.holodex.net": return ("https://discord.com/api/oauth2/authorize?client_id=826055534318583858&redirect_uri=https%3A%2F%2Fstaging.holodex.net%2Frelaybot&response_type=code&scope=guilds%20identify");
+                case "holodex.net": return ("https://discord.com/api/oauth2/authorize?client_id=826055534318583858&redirect_uri=https%3A%2F%2Fholodex.net%2Frelaybot&response_type=code&scope=guilds%20identify");
+                default: return ("");
+            }
+        },
+    },
+    watch: {
+        // eslint-disable-next-line func-names
+        "$route.query.code": function () {
+            if ((this.$route.name === "relaybot") && this.$route.query.code) {
+                this.init();
+            }
+        },
+    },
+    mounted() {
+        this.init();
+    },
+    methods: {
+        init() {
+            this.loggedIn = false;
+            if (!this.$route.query.code) {
+                this.loggedIn = false;
+                return;
+            }
+
+            let mode = 3;
+            // eslint-disable-next-line no-restricted-globals
+            switch (location.hostname) {
+                case "localhost":
+                    mode = 0;
+                    break;
+                case "staging.holodex.net":
+                    mode = 1;
+                    break;
+                case "holodex.net":
+                    mode = 2;
+                    break;
+                default:
+                    mode = 3;
+                    break;
+            }
+
+            backendApi.relayBotLogin(this.$route.query.code, mode).then(({ status, data }) => {
+                if (status === 200) {
+                    this.selectedChannel = -1;
+                    this.selectedGuild = -1;
+                    this.loggedIn = true;
+                    this.accessToken = data.access_token;
+                    this.guilds = data.guilds.map((e) => ({
+                        id: e.id,
+                        name: e.name,
+                        admin: e.admin,
+                        bot: false,
+                    }));
+                    this.checkGuild();
+                }
+            }).catch(() => {
+                this.loggedIn = false;
+            });
+        },
+        checkGuild() {
+            backendApi.relayBotCheckBotPresence(this.guilds.map((e) => e.id)).then(({ status, data }) => {
+                if (status === 200) {
+                    this.guilds = this.guilds.map((e) => {
+                        e.bot = data.includes(e.id);
+                        return e;
+                    });
+                }
+            }).catch(() => {
+                this.loggedIn = false;
+            });
+        },
+        loadChannel(index) {
+            this.channels = [];
+            this.selectedGuild = index;
+            this.selectedChannel = -1;
+
+            if ((this.guilds[this.selectedGuild].bot) && (this.guilds[this.selectedGuild].admin)) {
+                backendApi.relayBotGetChannels(this.guilds[this.selectedGuild].id).then(({ status, data }) => {
+                    if (status === 200) {
+                        this.channels = data.map((e) => ({
+                            id: e.id,
+                            name: e.name,
+                        }));
+                    }
+                }).catch((err) => {
+                    console.log(err);
+                });
+            }
+        },
+        loadSetting(index) {
+            this.selectedChannel = index;
+            this.channelInpt = "";
+            this.langInpt = {
+                text: TL_LANGS[0].text,
+                value: TL_LANGS[0].value,
+            };
+            this.saveNotif = "";
+            this.setting = [];
+            backendApi.relayBotGetSettingChannel(this.channels[this.selectedChannel].id).then(({ status, data }) => {
+                if (status === 200) {
+                    this.setting = data.SubChannel.map((e) => {
+                        if (!e.lang) { e.lang = "en"; }
+                        return e;
+                    });
+                }
+            }).catch((err) => {
+                console.log(err);
+            });
+        },
+        validateChannel(channelUrl) {
+            if (channelUrl.indexOf("https://www.youtube.com/channel/") !== 0) {
+                return undefined;
+            }
+            return (((channelUrl.indexOf("?") !== -1) ? channelUrl.slice(0, channelUrl.indexOf("?")) : channelUrl).slice(("https://www.youtube.com/channel/").length));
+        },
+        addSetting() {
+            if (this.validateChannel(this.channelInpt)) {
+                const setPush = {
+                    link: `YT_${this.validateChannel(this.channelInpt)}`,
+                    lang: this.langInpt.value,
+                };
+                if (this.setting.filter((e) => (e.link === setPush.link) && (e.lang === setPush.lang)).length === 0) {
+                    this.setting.push(setPush);
+                }
+                this.channelInpt = "";
+                this.langInpt = {
+                    text: TL_LANGS[0].text,
+                    value: TL_LANGS[0].value,
+                };
+            }
+        },
+        saveSetting() {
+            this.saveNotif = "Saving...";
+            backendApi.relayBotSubmitData(this.channels[this.selectedChannel].id, this.setting).then(({ status }) => {
+                if (status === 200) {
+                    this.saveNotif = "Saved!!";
+                }
+            }).catch((err) => {
+                this.saveNotif = err;
+            });
+        },
+    },
+};
+</script>
+
+<style>
+</style>

--- a/src/views/TLClient.vue
+++ b/src/views/TLClient.vue
@@ -346,7 +346,11 @@
             return-object
             @change="localPrefix = '[' + TLLang.value + '] '"
           />
-          <v-text-field v-model="mainStreamLink" readonly :label="$t(&quot;views.tlClient.settingPanel.mainStreamLink&quot;)" />
+          <v-text-field
+            v-model="mainStreamLink"
+            :label="$t(&quot;views.tlClient.settingPanel.mainStreamLink&quot;)"
+            :readonly="$route.query.video ? true : false"
+          />
           <v-card-title>{{ $t("views.tlClient.settingPanel.collabLink") }}</v-card-title>
           <v-text-field
             v-for="(AuxLink, index) in collabLinks"
@@ -541,18 +545,23 @@ export default {
                 if (this.activeChat[i].text === target) {
                     this.activeChat[i].IFrameEle = event.target;
                     switch (target.slice(0, 3)) {
-                        case "YT_":
-                            event.target.contentWindow?.postMessage({
-                                n: "HolodexSync",
-                                d: "Initiate",
-                            }, "https://www.youtube.com");
+                        case "YT_": {
+                            setTimeout(() => {
+                                event.target.contentWindow?.postMessage({
+                                    n: "HolodexSync",
+                                    d: "Initiate",
+                                }, "https://www.youtube.com");
+                            }, 1000);
                             break;
+                        }
 
                         case "TW_":
-                            event.target.contentWindow?.postMessage({
-                                n: "HolodexSync",
-                                d: "Initiate",
-                            }, "https://www.twitch.tv");
+                            setTimeout(() => {
+                                event.target.contentWindow?.postMessage({
+                                    n: "HolodexSync",
+                                    d: "Initiate",
+                                }, "https://www.twitch.tv");
+                            }, 1000);
                             break;
 
                         default:
@@ -636,6 +645,7 @@ export default {
             this.$store.commit("tlclient/setId", parseVideoID.id);
             this.$store.dispatch("tlclient/fetchVideo");
 
+            this.localPrefix = `[${this.TLLang.value}] `;
             this.modalNexus = false;
             if (this.firstLoad) {
                 this.loadChat(this.mainStreamLink);


### PR DESCRIPTION
There are 2 things that I want to make sure that you guys are okay with

- relay bot setting page is only in English.
It's just a temporary fix in hope that one day lunabot will be interested in putting its bot setting GUI in holodex, hence strengthening its ties with holodex. At that point, I'm planning to fully retire mchatx bot and help writing a proper GUI for that.
(p.s I did ask tam before and he said no, sadly enough)

- I put button to go to tlclient, script manager, script editor, and relay bot setting page in the navbar but you'll have to click a small arrow down button to reveal it. I think that is good enough to hide tl features out of normal users' eyes.