### PR TITLE
Fix loading orgs when the "orgs" input in clicked in the search form

### DIFF
--- a/src/components/search/SearchForm.vue
+++ b/src/components/search/SearchForm.vue
@@ -16,7 +16,7 @@
               item-text="name"
               :label="$t('component.search.type.org')"
               :prepend-icon="mdiAccountMultiple"
-              @click="loadOrgs"
+              @focus="loadOrgs"
             />
           </v-col>
 


### PR DESCRIPTION
Fixes #585 

The click even doesn't fire while the dropdown is closed, so it doesn't get called when you open the dropdown the first time. Switching to the focus event fixes the issue.

Something to note: orgs aren't loaded until the orgs dropdown is opened, but the topics are loaded when the component is mounted. Might be worth updating one of the two so they're consistent.