### PR TITLE
Avoid infinite loop in Script Editor if `tableContainer` is not present

### DIFF
--- a/src/views/TLScriptEditor.vue
+++ b/src/views/TLScriptEditor.vue
@@ -952,6 +952,9 @@ export default {
     },
     created() {
         window.addEventListener("resize", this.onResize);
+        if (!this.$refs.tableContainer?.$el) {
+            return;
+        }
         const checker = setInterval(() => {
             this.tableHeight = this.$refs.tableContainer.$el.clientHeight - 20;
             if (this.tableHeight !== 0) {
@@ -978,6 +981,9 @@ export default {
         },
         onResize() {
             this.tableHeight = 0;
+            if (!this.$refs.tableContainer?.$el) {
+                return;
+            }
             const checker = setInterval(() => {
                 this.tableHeight = this.$refs.tableContainer.$el.clientHeight - 20;
                 if (this.tableHeight !== 0) {


### PR DESCRIPTION
When `tableContainer` is not initialized (e.g. due to authorization issues), the following `setInterval`s run infinitely, firing `30 * (resizeCount + 1)` errors per second.