### PR TITLE
Attach menus in cliplist below video

### DIFF
--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -191,9 +191,12 @@
       <!-- Vertical dots menu -->
       <v-menu
         v-model="showMenu"
+        attach
         bottom
+        left
         :close-on-content-click="false"
         nudge-top="20px"
+        nudge-left="40px"
       >
         <template #activator="{ on, attrs }">
           <v-btn


### PR DESCRIPTION
Make vertical-dots menus in clip lists ~~become KFP~~ attached to bottom left. This keeps them within the list block and doesn't allow to have fixed position while scrolling.

A lot of menus in other places have similar issues, but no idea if it can be helped without overriding vue semantics by explicit custom styling.