### PR TITLE
Fade out "inactive" channels on channel list

### DIFF
--- a/src/components/channel/ChannelList.vue
+++ b/src/components/channel/ChannelList.vue
@@ -76,7 +76,7 @@
         <!-- Channel list -->
         <template v-for="(channel, index2) in group.items">
           <v-divider :key="'divider-' + index2" />
-          <v-lazy :key="channel.id" min-height="100">
+          <v-lazy :key="channel.id" min-height="100" :style="[channel.inactive ? {'opacity' : 0.5} : {'opacity' : 1}]">
             <v-list-item
               v-if="channel"
               :to="`/channel/${channel.id}`"
@@ -100,7 +100,7 @@
   <v-list v-else class="pa-0">
     <template v-for="(channel, index) in channels">
       <v-divider :key="'divider-' + index" />
-      <v-lazy :key="channel.id" min-height="88">
+      <v-lazy :key="channel.id" min-height="88" :style="[channel.inactive ? {'opacity' : 0.5} : {'opacity' : 1}]">
         <v-list-item
           v-if="channel"
           :to="`/channel/${channel.id}`"


### PR DESCRIPTION
Have channels considered "inactive" appear faded out on the channel list. This is an alternative to setting their subgroup to Inactive, allowing them to retain their previous subgroup while having visual indication that the streamer is no longer uploading.

~~Note this currently doesn't function, as the `/channels` endpoint does not include the `inactive` attribute. This was instead tested with various other available attributes, such as checking for certain topics in `top_topics` or having X amount of clips.~~