### PR TITLE
Use internal avatars in collaborator list

### DIFF
--- a/src/components/channel/ChannelChip.vue
+++ b/src/components/channel/ChannelChip.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script lang="ts">
-import { resizeChannelPhoto } from "@/utils/functions";
+import { getChannelPhoto } from "@/utils/functions";
 import ChannelSocials from "@/components/channel/ChannelSocials.vue";
 
 export default {
@@ -88,8 +88,7 @@ export default {
             return this.channel.name;
         },
         photo() {
-            if (!this.channel.photo) return "";
-            return resizeChannelPhoto(this.channel.photo, this.size);
+            return getChannelPhoto(this.channel.id, this.size);
         },
     },
 };


### PR DESCRIPTION
Use images like https://holodex.net/statics/channelImg/UCsUj0dszADCGbF3gNrQEuSQ/100.png instead of https://yt3.ggpht.com/zczPLp_sj4Qq3CyoGzfXifOdwE7aMHRpUdqbMD9UKvjddBG2NdMrCKElCMUOS6x85BMr2VGuAA=s88-c-k-c0x00ffffff-no-rj-mo in the list of participants of collab video.

This seems to be the only place where `util/functions/resizeChannelPhoto()` is used now, so it might be a subject for cleanup.