### PR TITLE
Filter out collab videos if all related collaborators are blocked

### DIFF
--- a/src/mixins/filterVideos.js
+++ b/src/mixins/filterVideos.js
@@ -10,17 +10,20 @@ export default {
             const blockedChannels = this.$store.getters["settings/blockedChannelIDs"];
             const ignoredTopics = this.$store.getters["settings/ignoredTopics"];
             const favoriteChannels = this.$store.getters["favorites/favoriteChannelIDs"];
-            const org = forOrg || this.$store.state.currentOrg.name;
+            forOrg ||= this.$store.state.currentOrg.name;
 
             let keep = true;
             const channelId = v.channel_id || v.channel.id;
+            const isFavoritedOrInOrg = v.channel.org === forOrg || favoriteChannels.has(channelId);
 
             if (!ignoreBlock) {
                 keep &&= !blockedChannels.has(channelId);
             }
 
-            if (hideCollabs) {
-                keep &&= (v.channel.org === org) || favoriteChannels.has(channelId);
+            if (!isFavoritedOrInOrg) {
+                keep &&= !hideCollabs && !v.mentions?.every(
+                    ({ id, org }) => blockedChannels.has(id) || (org !== forOrg && !favoriteChannels.has(id))
+                );
             }
 
             if (hideIgnoredTopics) {

--- a/src/store/home.module.js
+++ b/src/store/home.module.js
@@ -32,6 +32,7 @@ const actions = {
             return api
                 .live({
                     type: "placeholder,stream",
+                    include: "mentions",
                     org: rootState.currentOrg.name,
                 })
                 .then((res) => {


### PR DESCRIPTION
Example: Holo*-only list, user has all men blocked. In this case, we should exclude videos like [this one](https://staging.holodex.net/watch/zvg7obJGNJY) from the list, because the only Holo* participant is Aruran.