### PR TITLE
docs(env): update default value and add missing env variable

### DIFF
--- a/.env.placeholder
+++ b/.env.placeholder
@@ -1,2 +1,3 @@
 # Uncomment this if you want api requests to be routed to a local api server
-#API_BASE_URL=http://localhost:18080
+#API_BASE_URL=http://localhost:2434
+#REWRITE_API_ROUTES=true


### PR DESCRIPTION
This sets the API base url to the default port as set in the API source code. Additionally, this also adds a commented out `REWRITE_API_ROUTES` environment variable (used in `vite.config.js`).

It took me way too long to figure out why I got 404's, so hopefully this saves time for others in the future.