### PR TITLE
Display more information in channel autocompletes

### DIFF
--- a/src/components/channel/ChannelAutocomplete.vue
+++ b/src/components/channel/ChannelAutocomplete.vue
@@ -47,21 +47,13 @@ export default {
                 })
                 .then(({ data }) => {
                     this.searchResults = data.map((d) => ({
-                        text: (d.name.includes(`${d.english_name || d.name}`) ? this.getChannelName(d) : `${this.getChannelName(d)} / ${this.getInverseName(d)}`) + ` (${d.id})`,
+                        text: `${d.english_name || ""} ${d.name} (${d.id})`,
                         value: d,
                     }));
                 });
         }, 500),
     },
     methods: {
-        getChannelName(channel) {
-            const prop = this.$store.state.settings.nameProperty;
-            return channel[prop] || channel.name;
-        },
-        getInverseName(channel) {
-            const prop = this.$store.state.settings.nameProperty === "name" ? "english_name" : "name";
-            return channel[prop] || channel.name;
-        },
     },
 };
 </script>

--- a/src/components/channel/ChannelAutocomplete.vue
+++ b/src/components/channel/ChannelAutocomplete.vue
@@ -47,7 +47,7 @@ export default {
                 })
                 .then(({ data }) => {
                     this.searchResults = data.map((d) => ({
-                        text: `${d.english_name || ""} ${d.name} (${d.id})`,
+                        text: `${d.english_name ? (d.english_name + ',') : ""} ${d.name} (${d.id})`,
                         value: d,
                     }));
                 });

--- a/src/components/channel/ChannelAutocomplete.vue
+++ b/src/components/channel/ChannelAutocomplete.vue
@@ -47,7 +47,7 @@ export default {
                 })
                 .then(({ data }) => {
                     this.searchResults = data.map((d) => ({
-                        text: this.getChannelName(d),
+                        text: (d.name.includes(`${d.english_name || d.name}`) ? this.getChannelName(d) : `${this.getChannelName(d)} / ${this.getInverseName(d)}`) + ` (${d.id})`,
                         value: d,
                     }));
                 });
@@ -56,6 +56,10 @@ export default {
     methods: {
         getChannelName(channel) {
             const prop = this.$store.state.settings.nameProperty;
+            return channel[prop] || channel.name;
+        },
+        getInverseName(channel) {
+            const prop = this.$store.state.settings.nameProperty === "name" ? "english_name" : "name";
             return channel[prop] || channel.name;
         },
     },


### PR DESCRIPTION
Channel autocompletes now include the channel ID, and also their alternate name if the original name doesn't contain it (which further allows searching using the name option the user didn't select.)
![image](https://user-images.githubusercontent.com/41271523/187073985-de58dd80-6e25-4ed9-a668-4a976eabf0de.png)
