### PR TITLE
Adjust livechat z-index to fix archive sync time tooltip

### DIFF
--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -239,6 +239,7 @@ export default {
     position: relative;
     display: flex;
     flex-direction: column;
+    z-index: 0;
 }
 
 .watch-live-chat.fluid {


### PR DESCRIPTION
Fixes the archive sync time tooltip [appearing behind embedded YTC cells](https://discord.com/channels/796190073271353385/801759432450375700/1000789640988610692).
Definitely will not break anything in the future