### PR TITLE
Add Twitter feed tab to channel pages

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ const Channel = () => import("../views/Channel.vue");
 const Channels = () => import("../views/Channels.vue");
 const ChannelVideos = () => import("../views/channel_views/ChannelVideos.vue");
 const ChannelAbout = () => import("../views/channel_views/ChannelAbout.vue");
+const ChannelTweets = () => import("../views/channel_views/ChannelTweets.vue");
 const Watch = () => import("../views/Watch.vue");
 const About = () => import("../views/About.vue");
 const Search = () => import("../views/Search.vue");
@@ -84,6 +85,11 @@ const routes = [
                 path: "about",
                 name: "channel_about",
                 component: ChannelAbout,
+            },
+            {
+                path: "tweets",
+                name: "channel_tweets",
+                component: ChannelTweets,
             },
             {
                 path: "music",

--- a/src/views/Channel.vue
+++ b/src/views/Channel.vue
@@ -107,6 +107,11 @@ export default {
                     path: `/channel/${this.id}/about`,
                     name: `${this.$t("views.channel.about")}`,
                 },
+                {
+                    path: `/channel/${this.id}/tweets`,
+                    name: "Tweets",
+                    hide: this.channel.type === "subber" || !this.channel.twitter,
+                },
                 // { path: `/channel/${this.channel_id}/stats`, name: "Stats" },
             ];
         },

--- a/src/views/channel_views/ChannelTweets.vue
+++ b/src/views/channel_views/ChannelTweets.vue
@@ -2,7 +2,7 @@
   <v-container>
     <a
       class="twitter-timeline"
-      :data-height="$store.state.isMobile ? '410' : '100%'"
+      :data-height="$store.state.isMobile ? '700%' : '800%'"
       :data-theme="$vuetify.theme.dark ? 'dark' : 'light'"
       :href="`https://twitter.com/${channelTwitter}`"
     >

--- a/src/views/channel_views/ChannelTweets.vue
+++ b/src/views/channel_views/ChannelTweets.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-container>
+    <a
+      class="twitter-timeline"
+      :data-height="$store.state.isMobile ? '410' : '100%'"
+      :data-theme="$vuetify.theme.dark ? 'dark' : 'light'"
+      :href="`https://twitter.com/${channelTwitter}`"
+    >
+      Loading Tweets from {{ channelName }}...
+    </a>
+  </v-container>
+</template>
+
+<script lang="ts">
+
+export default {
+    name: "ChannelTweets",
+    metaInfo() {
+        const vm = this;
+        return {
+            title: `${vm.channelName} - Tweets - Holodex`,
+        };
+    },
+    computed: {
+        channel() {
+            return this.$store.state.channel.channel;
+        },
+        channelName() {
+            const prop = this.$store.state.settings.nameProperty;
+            return this.channel[prop] || this.channel.name;
+        },
+        channelTwitter() {
+            return this.channel.twitter;
+        },
+    },
+    mounted() {
+        const tweetScript = document.createElement("script");
+        tweetScript.setAttribute("src", "https://platform.twitter.com/widgets.js");
+        document.head.appendChild(tweetScript);
+    },
+};
+</script>


### PR DESCRIPTION
Allows users to directly view a channel's Twitter feed from Holodex.
![image](https://user-images.githubusercontent.com/41271523/187474857-e92f1e05-cc00-4245-ad79-a45f789170eb.png)