### PR TITLE
Fix blockfilter in clips

### DIFF
--- a/src/components/video/ConnectedVideoList.vue
+++ b/src/components/video/ConnectedVideoList.vue
@@ -398,9 +398,11 @@ export default {
             this.init();
         },
         getLoadFn() {
-            let inclusion = "";
-            if (this.tab === this.Tabs.ARCHIVE) inclusion = "mentions,clips";
-            else if (this.tab === this.Tabs.LIVE_UPCOMING) inclusion = "mentions";
+            const inclusion = {
+                [this.Tabs.ARCHIVE]: "mentions,clips",
+                [this.Tabs.LIVE_UPCOMING]: "mentions",
+                [this.Tabs.CLIPS]: "mentions",
+            }[this.tab] ?? "";
 
             const query = {
                 status: this.tab === this.Tabs.ARCHIVE ? "past,missing" : "past",


### PR DESCRIPTION
Enabling `mentions` in Clips tab allows to filter out clips when all mentioned channels are blocked by user.