### PR TITLE
Remove width limit from song popup on watch pages

### DIFF
--- a/src/components/watch/WatchHighlights.vue
+++ b/src/components/watch/WatchHighlights.vue
@@ -27,7 +27,6 @@
             <song-item
               v-else-if="b.song"
               :song="b.song"
-              style="max-width: 350px"
               color="white--text"
             />
           </v-tooltip>


### PR DESCRIPTION
A lot of songs with slightly longer names or artists get cropped at the moment in the popup, so this removes the limit to allow songs to use as much space as they need.