### PR TITLE
Implement Chat & TLdex on edit page while live

### DIFF
--- a/src/views/EditVideo.vue
+++ b/src/views/EditVideo.vue
@@ -21,6 +21,51 @@
             />
           </template>
         </WatchFrame>
+        <div v-if="isLive" class="watch-live-chat">
+          <WatchToolbar :video="video">
+            <template #buttons>
+              <v-tooltip bottom>
+                <template #activator="{ on, attrs }">
+                  <v-btn
+                    icon
+                    lg
+                    :color="showTL ? 'primary' : ''"
+                    v-bind="attrs"
+                    @click="showTL = !showTL"
+                    v-on="on"
+                  >
+                    <v-icon>
+                      {{ icons.tlChat }}
+                    </v-icon>
+                  </v-btn>
+                </template>
+                <span>{{
+                  showTL
+                    ? $t("views.watch.chat.hideTLBtn")
+                    : $t("views.watch.chat.showTLBtn")
+                }}</span>
+              </v-tooltip>
+              <v-btn
+                icon
+                lg
+                :color="showLiveChat ? 'primary' : ''"
+                @click="showLiveChat = !showLiveChat"
+              >
+                <v-icon>
+                  {{ icons.ytChat }}
+                </v-icon>
+              </v-btn>
+            </template>
+          </WatchToolbar>
+          <WatchLiveChat
+            v-model="chatStatus"
+            class="sidebar chat"
+            :video="video"
+            :current-time="currentTime"
+            @videoUpdate="handleVideoUpdate"
+            @timeJump="seekTo"
+          />
+        </div>
         <div v-if="video.comments.length" class="comment-scroller">
           <CommentSongParser
             v-if="currentTab === 1"
@@ -121,10 +166,12 @@ import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 import WatchInfo from "@/components/watch/WatchInfo.vue";
 import WatchFrame from "@/components/watch/WatchFrame.vue";
 import WatchComments from "@/components/watch/WatchComments.vue";
+import WatchLiveChat from "@/components/watch/WatchLiveChat.vue";
+import WatchToolbar from "@/components/watch/WatchToolbar.vue";
 import VideoEditSongs from "@/components/edit/VideoEditSongs.vue";
 import VideoEditMentions from "@/components/edit/VideoEditMentions.vue";
 import CommentSongParser from "@/components/media/CommentSongParser.vue";
-import { decodeHTMLEntities } from "@/utils/functions";
+import { decodeHTMLEntities, syncState } from "@/utils/functions";
 // import { dayjs } from "@/utils/time";
 import api from "@/utils/backend-api";
 
@@ -141,6 +188,8 @@ export default {
         WatchFrame,
         VideoEditSongs,
         WatchComments,
+        WatchLiveChat,
+        WatchToolbar,
         VideoEditMentions,
         Youtube,
         CommentSongParser,
@@ -171,6 +220,22 @@ export default {
         };
     },
     computed: {
+        ...syncState("watch", ["showTL", "showLiveChat"]),
+        chatStatus: {
+            get() {
+                return {
+                    showTlChat: this.showTL,
+                    showYtChat: this.showLiveChat,
+                };
+            },
+            set(val: any) {
+                this.showTL = val.showTlChat;
+                this.showLiveChat = val.showYtChat;
+            },
+        },
+        isLive() {
+            return this.video && this.video.status === "live";
+        },
         videoId() {
             return this.$route.params.id || this.$route.query.v;
         },
@@ -246,6 +311,12 @@ export default {
                     this.hasError = true;
                     console.error(e);
                 });
+        },
+        handleVideoUpdate(update) {
+            if (!update?.status || !update?.start_actual) return;
+            this.video.live_viewers = update.live_viewers;
+            this.video.status = update.status;
+            this.video.start_actual = update.start_actual;
         },
         async populateTopics() {
             this.topics = (await api.topics()).data.map((topic) => ({


### PR DESCRIPTION
Adds chat and TLdex under the video frame if the stream is live, where the comments dropdown would normally be when archived. This is a useful utility for users that are live-tagging a video who may also want to interact with/view the chat and TLs without having another window open.

May need some polish, but it functions for its purpose.
![image](https://user-images.githubusercontent.com/41271523/191821720-19e0bb4d-35c2-4e24-a707-347b750572a0.png)
