### PR TITLE
Add video refresh button

### DIFF
--- a/src/components/watch/WatchToolbar.vue
+++ b/src/components/watch/WatchToolbar.vue
@@ -15,6 +15,20 @@
           <v-btn
             icon
             lg
+            v-bind="attrs"
+            @click="reloadVideo()"
+            v-on="on"
+          >
+            <v-icon>{{ icons.mdiRefresh }}</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ "Reload Video Frame" }}</span>
+      </v-tooltip>
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            icon
+            lg
             :color="hasSaved ? 'primary' : ''"
             v-bind="attrs"
             @click="toggleSaved"
@@ -84,6 +98,10 @@ export default {
         },
         goBack() {
             this.$router.go(-1);
+        },
+        reloadVideo() {
+            const curr = document.querySelector(`[id^="youtube-player"]`);
+            curr.contentWindow.location.replace(curr.src);
         },
     },
 };


### PR DESCRIPTION
Adds a button allowing users to refresh the video frame independently from the page. This was already possible by right click, but having a dedicated button for it makes it more discoverable and makes fixing player issues far easier as an entire page refresh isn't needed.

![image](https://user-images.githubusercontent.com/41271523/191844058-ae31a809-38bf-46df-98b1-bfbf0e61f2ef.png)
