### PR TITLE
Minor Theatre Mode improvements

### DIFF
--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -22,7 +22,7 @@
     /> -->
     <KeyPress
       key-event="keyup"
-      :key-code="84"
+      :multiple-keys="multiple"
       @success="toggleTheaterMode"
     />
     <div ref="watchLayout" class="d-flex flex-grow-1 left">
@@ -206,6 +206,13 @@ export default {
     data() {
         return {
             startTime: 0,
+            multiple: [
+                {
+                    keyCode: 84, // t
+                    modifiers: ['altKey'],
+                    preventDefault: true,
+                },
+            ],
             mdiOpenInNew,
             mdiDockLeft,
             mdiThumbUp,

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -15,11 +15,6 @@
       'show-highlights-bar': showHighlightsBar
     }"
   >
-    <!-- <KeyPress
-      key-event="keyup"
-      :multiple-keys="altTHotKey"
-      @success="toggleTheaterMode"
-    /> -->
     <KeyPress
       key-event="keyup"
       :key-code="84"
@@ -214,14 +209,6 @@ export default {
             playlistIndex: -1,
             currentTime: 0,
             player: null,
-            altTHotKey: [
-                {
-                    keyCode: 84, // T
-                    modifiers: ["alt"],
-                    preventDefault: false,
-                },
-            ],
-
         };
     },
     computed: {

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -22,8 +22,8 @@
     /> -->
     <KeyPress
       key-event="keyup"
-      :key-code="27"
-      @success="theaterMode = false"
+      :key-code="84"
+      @success="toggleTheaterMode"
     />
     <div ref="watchLayout" class="d-flex flex-grow-1 left">
       <div class="d-flex flex-column flex-grow-1">
@@ -212,7 +212,6 @@ export default {
             playlistIndex: -1,
             currentTime: 0,
             player: null,
-            theaterMode: false,
             altTHotKey: [
                 {
                     keyCode: 84, // T
@@ -225,7 +224,7 @@ export default {
     },
     computed: {
         ...mapState("watch", ["video", "isLoading", "hasError"]),
-        ...syncState("watch", ["showTL", "showLiveChat"]),
+        ...syncState("watch", ["showTL", "showLiveChat", "theaterMode"]),
         chatStatus: {
             get() {
                 return {

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -22,7 +22,9 @@
     /> -->
     <KeyPress
       key-event="keyup"
-      :multiple-keys="multiple"
+      :key-code="84"
+      :modifiers="['altKey']"
+      :prevent-default="true"
       @success="toggleTheaterMode"
     />
     <div ref="watchLayout" class="d-flex flex-grow-1 left">
@@ -206,13 +208,6 @@ export default {
     data() {
         return {
             startTime: 0,
-            multiple: [
-                {
-                    keyCode: 84, // t
-                    modifiers: ['altKey'],
-                    preventDefault: true,
-                },
-            ],
             mdiOpenInNew,
             mdiDockLeft,
             mdiThumbUp,


### PR DESCRIPTION
- Theatre mode can now be toggled on/off with `alt + t` as labelled. Previously, it could only be turned off with `Esc`, with no shortcut to enable it.
- Option now persists through page loads