### PR TITLE
Restore the Org switcher hint tooltip

### DIFF
--- a/src/components/common/OrgSelector.vue
+++ b/src/components/common/OrgSelector.vue
@@ -33,13 +33,26 @@
                 class="primary--text"
                 :class="{ 'text--lighten-2': darkMode, 'text--darken-4': !darkMode }"
               >dex</span>
-              <v-icon
-                size="30"
-                class="change-org-icon"
-                :class="{ 'rotate-180': activator.attrs['aria-expanded'] === 'true' }"
+              <v-tooltip
+                v-model="showOrgTip"
+                right
+                bottom
+                z-index="120"
+                content-class="first-visit-tooltip"
               >
-                {{ icons.mdiMenuDown }}
-              </v-icon>
+                <template #activator="{}">
+                  <v-icon
+                    size="30"
+                    class="change-org-icon"
+                    :class="{ 'rotate-180': activator.attrs['aria-expanded'] === 'true' }"
+                    v-on="activator.on"
+                  >
+                    {{ icons.mdiMenuDown }}
+                  </v-icon>
+                </template>
+                <div>{{ $t("views.app.nowSupportsMultiOrg") }}</div>
+                <div>{{ $t("views.app.loginCallToAction") }}</div>
+              </v-tooltip>
             </div>
           </slot>
         </template>
@@ -169,6 +182,14 @@ export default {
                 return this.$store.commit("setVisited");
             },
         },
+        showOrgTip: {
+            get() {
+                return this.$store.state.showOrgTip && navigator.userAgent && !navigator.userAgent.includes("Googlebot");
+            },
+            set() {
+                return this.$store.commit("setOrgTip");
+            },
+        },
         sortedOrgs() {
             let list = this.orgs.slice();
             if (this.search) {
@@ -243,9 +264,9 @@ export default {
 }
 
 .first-visit-tooltip {
-    width: 80%;
+    width: auto;
     max-width: 480px;
-    background: rgb(91, 157, 211);
+    background: rgb(40, 40, 40);
     font-weight: 500;
     box-shadow: 2px 2px 4px black;
 }
@@ -253,9 +274,9 @@ export default {
     content: "";
     position: absolute;
     top: -10px;
-    left: 105px;
+    left: 55px;
     width: 0;
-    border-bottom: 10px solid rgb(91, 157, 211);
+    border-bottom: 10px solid rgb(40, 40, 40);
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
 }

--- a/src/components/nav/MainNav.vue
+++ b/src/components/nav/MainNav.vue
@@ -305,7 +305,7 @@ export default {
                 },
             ];
         },
-        ...mapState(["firstVisit"]),
+        ...mapState(["firstVisit", "showOrgTip"]),
     },
     watch: {
         // toggle navdrawer when navigating between watch pages on desktop
@@ -319,8 +319,13 @@ export default {
         },
     },
     created() {
+        const vm = this;
+        if (this.$store.state.showOrgTip) {
+            setTimeout(() => {
+                vm.$store.commit("setOrgTip");
+            }, 20000);
+        }
         if (this.$store.state.firstVisit) {
-            const vm = this;
             setTimeout(() => {
                 vm.$store.commit("setVisited");
             }, 30000);

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -287,8 +287,9 @@ views:
     update_btn: Update
     close_btn: Close
     check_about_page: Visit the About page to see new changes
-    nowSupportsMultiOrg: Holodex now supports multiple organizations.
-    loginCallToAction: Login to gather your own favorites!
+    nowSupportsMultiOrg: >-
+      Tip: You can change the organization here!
+    loginCallToAction: Login to set your own favorites.
   about:
     add_my_channel: Channel Request
   watch:

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -35,6 +35,7 @@ function defaultState() {
     return {
         // other
         firstVisit: true,
+        showOrgTip: true,
         showUpdateDetails: false,
         firstVisitMugen: true,
         lastShownInstallPrompt: 0,
@@ -84,9 +85,9 @@ function defaultState() {
  *     Configure Synchronized Modules & Mutations across tabs
  *------------------------* */
 const syncedModules = /^(?:playlist|settings|history)/;
-const syncedMutations = new Set(["resetState", "setUser", "setShowUpdatesDetail", "firstVisit", "firstVisitMugen", "favorites/setFavorites", "favorites/resetFavorites", "favorites/setLive", "multiview/addPresetLayout", "multiview/removePresetLayout", "multiview/togglePresetAutoLayout", "multiview/setAutoLayout"]);
+const syncedMutations = new Set(["resetState", "setUser", "setShowUpdatesDetail", "showOrgTip", "firstVisit", "firstVisitMugen", "favorites/setFavorites", "favorites/resetFavorites", "favorites/setLive", "multiview/addPresetLayout", "multiview/removePresetLayout", "multiview/togglePresetAutoLayout", "multiview/setAutoLayout"]);
 
-const persistedPaths = ["orgs", "playlist", "settings", "history", "migration", "multiview", "channels.cardView", "channels.sort", "currentOrg", "favorites.favorites", "lastShownInstallPrompt", "firstVisit", "firstVisitMugen", "orgFavorites", "showUpdateDetails", "userdata", "watch.showLiveChat", "watch.showTL", "watch.theaterMode", "currentGridSize"];
+const persistedPaths = ["orgs", "playlist", "settings", "history", "migration", "multiview", "channels.cardView", "channels.sort", "currentOrg", "favorites.favorites", "lastShownInstallPrompt", "showOrgTip", "firstVisit", "firstVisitMugen", "orgFavorites", "showUpdateDetails", "userdata", "watch.showLiveChat", "watch.showTL", "watch.theaterMode", "currentGridSize"];
 export default new Vuex.Store({
     plugins: [
         createPersistedState({
@@ -143,6 +144,9 @@ export default new Vuex.Store({
         },
         setVisited(state) {
             state.firstVisit = false;
+        },
+        setOrgTip(state) {
+            state.showOrgTip = false;
         },
         setVisitedMugen(state) {
             state.firstVisitMugen = false;


### PR DESCRIPTION
As discussed [here](https://discord.com/channels/796190073271353385/801760512907935764/1041727732314296331).
This will show for all users the next time they open the site after updating.
![image](https://user-images.githubusercontent.com/41271523/202024681-f1d35091-da62-4e32-91a4-e72f56dba2b9.png)
