### PR TITLE
Add +-60s buttons to ArchiveTranslations

### DIFF
--- a/src/components/chat/ArchiveTranslations.vue
+++ b/src/components/chat/ArchiveTranslations.vue
@@ -12,11 +12,22 @@
           icon
           x-small
           class="mr-1"
+          title="-60s"
+          @click="timeOffset -= 60000"
+        >
+          <v-icon>
+            {{ mdiChevronDoubleLeft }}
+          </v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          x-small
+          class="mr-1"
           title="-2s"
           @click="timeOffset -= 2000"
         >
           <v-icon>
-            {{ mdiTransferLeft }}
+            {{ mdiChevronLeft }}
           </v-icon>
         </v-btn>
         <code class="mr-1">{{ `${timeOffset >= 0 ? "+" : ""}${timeOffset / 1000}s` }}</code>
@@ -28,7 +39,18 @@
           @click="timeOffset += 2000"
         >
           <v-icon>
-            {{ mdiTransferRight }}
+            {{ mdiChevronRight }}
+          </v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          x-small
+          class="mr-1"
+          title="+60s"
+          @click="timeOffset += 60000"
+        >
+          <v-icon>
+            {{ mdiChevronDoubleRight }}
           </v-icon>
         </v-btn>
         <v-btn
@@ -93,7 +115,7 @@
 
 <script lang="ts">
 import VirtualList from "vue-virtual-scroll-list";
-import { mdiTransferRight, mdiTransferLeft } from "@mdi/js";
+import { mdiChevronLeft, mdiChevronDoubleLeft, mdiChevronRight, mdiChevronDoubleRight } from "@mdi/js";
 import WatchLiveTranslationsSetting from "./LiveTranslationsSetting.vue";
 import ChatMessage from "./ChatMessage.vue";
 import chatMixin from "./chatMixin";
@@ -112,8 +134,10 @@ export default {
             ChatMessage,
             curIndex: 0,
             timeOffset: 0, // for offsetting archive TL
-            mdiTransferRight,
-            mdiTransferLeft };
+            mdiChevronLeft,
+            mdiChevronDoubleLeft,
+            mdiChevronRight,
+            mdiChevronDoubleRight };
     },
     computed: {
         dividedTLs() {


### PR DESCRIPTION
### Rational: 
I've ran into an issue whereby I needed to set the offset of the archived translation to -446s.
However, there is only a button to adjust the offset in 2s intervals. This meant that I needed to press the button 223 times, which was not very pleasant. 

### Before:
![image](https://user-images.githubusercontent.com/41221030/202851366-77a1aab3-ce77-4405-bc06-eacbfc3772c7.png)

### After:
![image](https://user-images.githubusercontent.com/41221030/202851418-03731b98-b180-43f9-85e4-18fb85e9c98b.png)


- Added buttons to adjust the offset of archived translations by 60s interval.
- Changed the images of the 2s offset buttons from mdiTransferLeft/mdiTransferRight to mdiChevronLeft/mdiChevronRight so that it's clear from a glance which button is 2s and which is 60s.

