### PR TITLE
Add ability to manually input timeoffset in ArchiveTranslations 

### DIFF
--- a/src/components/chat/ArchiveTranslations.vue
+++ b/src/components/chat/ArchiveTranslations.vue
@@ -12,17 +12,6 @@
           icon
           x-small
           class="mr-1"
-          title="-60s"
-          @click="timeOffsetSeconds -= 60"
-        >
-          <v-icon>
-            {{ mdiChevronDoubleLeft }}
-          </v-icon>
-        </v-btn>
-        <v-btn
-          icon
-          x-small
-          class="mr-1"
           title="-2s"
           @click="timeOffsetSeconds -= 2"
         >
@@ -55,17 +44,6 @@
         >
           <v-icon>
             {{ mdiChevronRight }}
-          </v-icon>
-        </v-btn>
-        <v-btn
-          icon
-          x-small
-          class="mr-1"
-          title="+60s"
-          @click="timeOffsetSeconds += 60"
-        >
-          <v-icon>
-            {{ mdiChevronDoubleRight }}
           </v-icon>
         </v-btn>
         <v-btn

--- a/src/components/chat/ArchiveTranslations.vue
+++ b/src/components/chat/ArchiveTranslations.vue
@@ -13,7 +13,7 @@
           x-small
           class="mr-1"
           title="-60s"
-          @click="timeOffset -= 60000"
+          @click="timeOffsetSeconds -= 60"
         >
           <v-icon>
             {{ mdiChevronDoubleLeft }}
@@ -24,19 +24,34 @@
           x-small
           class="mr-1"
           title="-2s"
-          @click="timeOffset -= 2000"
+          @click="timeOffsetSeconds -= 2"
         >
           <v-icon>
             {{ mdiChevronLeft }}
           </v-icon>
         </v-btn>
-        <code class="mr-1">{{ `${timeOffset >= 0 ? "+" : ""}${timeOffset / 1000}s` }}</code>
+        <v-dialog v-model="dialog" width="250px">
+          <template #activator="{ on, attr }">
+            <code class="mr-1" v-bind="attr" v-on="on">{{ `${timeOffsetSeconds >= 0 ? "+" : ""}${timeOffsetSeconds}s` }}</code>
+          </template>
+          <v-card>
+            <v-card-text>
+              <v-container>
+                <v-text-field
+                  v-model.number="timeOffsetSeconds"
+                  type="number"
+                  suffix="s"
+                />
+              </v-container>
+            </v-card-text>
+          </v-card>
+        </v-dialog>
         <v-btn
           icon
           x-small
           class="mr-1"
           title="+2s"
-          @click="timeOffset += 2000"
+          @click="timeOffsetSeconds += 2"
         >
           <v-icon>
             {{ mdiChevronRight }}
@@ -47,7 +62,7 @@
           x-small
           class="mr-1"
           title="+60s"
-          @click="timeOffset += 60000"
+          @click="timeOffsetSeconds += 60"
         >
           <v-icon>
             {{ mdiChevronDoubleRight }}
@@ -133,7 +148,7 @@ export default {
         return {
             ChatMessage,
             curIndex: 0,
-            timeOffset: 0, // for offsetting archive TL
+            timeOffsetSeconds: 0, // for offsetting archive TL
             mdiChevronLeft,
             mdiChevronDoubleLeft,
             mdiChevronRight,
@@ -149,8 +164,8 @@ export default {
                     || item.name !== arr[index - 1].name
                     || !!item.breakpoint));
                 // timestamp is in milliseconds.
-                const newtime = item.timestamp + self.timeOffset;
-                const relativeMs = item.relativeMs + self.timeOffset;
+                const newtime = item.timestamp + self.timeOffsetSeconds * 1000;
+                const relativeMs = item.relativeMs + self.timeOffsetSeconds * 1000;
                 return { ...item, shouldHideAuthor, relativeMs, timestamp: newtime };
             });
         },


### PR DESCRIPTION
### Rationale
Someone on discord wanted a way for manual input instead of only the +-60s buttons.

### Before
![image](https://user-images.githubusercontent.com/41221030/204135371-53f50e17-3b96-420e-b43c-ab156d53a603.png)

### After
After clicking on the -62s, a small dialogue will appear on screen for manual input.
![image](https://user-images.githubusercontent.com/41221030/204135384-ea375d83-4f84-4280-b1ab-6e4f848c73ea.png)

Input is automatically validated by vue because the `<v-text-field>` is `type="number"`.

### Design Decisions Made
I've decided to create a pop up box so as to not change the current look.
Changing the `<code>` block that is currently used into an `<v-text-field>` is definitely possible, but doesn't really look as nice.

We could also potentially add more archive translations specific settings in the popup dialogue box in the future.

There are also no titles or labels in the pop up dialogue. 
We can definitely add them, but will need localized strings for them.