### PR TITLE
Add final indicator for inactive channels

### DIFF
--- a/src/components/channel/ChannelInfo.vue
+++ b/src/components/channel/ChannelInfo.vue
@@ -2,6 +2,16 @@
   <v-list-item-content>
     <v-list-item-title style="align-self: flex-start">
       <router-link :to="`/channel/${channel.id}`" class="no-decoration text-truncate">
+      <v-tooltip top v-if="channel.inactive">
+        <template v-slot:activator="{ on, attrs }">
+          <span v-bind="attrs" v-on="on">
+          🎓
+          </span>
+        </template>
+        <span>
+        {{ $t("component.channelInfo.inactiveChannel") }}
+        </span>
+      </v-tooltip>
         {{ channelName }}
       </router-link> <br>
       <template v-if="channel.yt_handle">

--- a/src/components/channel/ChannelInfo.vue
+++ b/src/components/channel/ChannelInfo.vue
@@ -4,12 +4,21 @@
       <router-link :to="`/channel/${channel.id}`" class="no-decoration text-truncate">
       <v-tooltip top v-if="channel.inactive">
         <template v-slot:activator="{ on, attrs }">
-          <span v-bind="attrs" v-on="on">
-          🎓
-          </span>
+          <v-btn
+            icon
+            v-on="on"
+            x-small
+            width="18"
+            class="plain-button"
+            :ripple="false"
+          >
+            <v-icon size="20">
+              {{ icons.mdiSchool }}
+            </v-icon>
+          </v-btn>
         </template>
         <span>
-        {{ $t("component.channelInfo.inactiveChannel") }}
+          {{ $t("component.channelInfo.inactiveChannel") }}
         </span>
       </v-tooltip>
         {{ channelName }}
@@ -163,5 +172,11 @@ export default {
 }
 .text--org:hover {
   opacity: 1.0;
+}
+.plain-button:before {
+  display: none
+}
+.plain-button:hover:before {
+  backgroundColor: transparent
 }
 </style>

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -16,6 +16,7 @@ component:
     subscriberCount: '{n} Subscribers'
     subscriberNA: Subscriber count unavailable
     totalViews: Total Views
+    inactiveChannel: This channel is no longer active.
   channelSocials:
     addToFavorites: Add to Favorites
     removeFromFavorites: Remove from Favorites

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -66,6 +66,7 @@ export {
     mdiRobot,
     mdiNoteEdit,
     mdiClockAlertOutline,
+    mdiSchool
 } from "@mdi/js";
 
 export const ytChat = "M20,2H4C2.9,2,2,2.9,2,4v18l4-4h14c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2zM9.9,10.8v3.8h-2v-3.8L5.1,6.6h2.4l1.4,2.2 l1.4-2.2h2.4L9.9,10.8zM18.9,8.6h-2v6h-2v-6h-2v-2h6V8.6z";


### PR DESCRIPTION
Alright, I know I've beaten this topic to death from previous additions but I wanted to revisit it one last time.
Previously, we had the `INACTIVE` subgroup in orgs to indicate a channel was inactive, however that's gradually being phased out in favour of leaving/moving them to their original group. Instead, this PR adds a small icon + hover tooltip next to their name.
![image](https://user-images.githubusercontent.com/41271523/211900785-df2ee5da-ca5a-402a-b1b6-e1fa35e9ea08.png)
