### PR TITLE
Add visible placeholder certainty

### DIFF
--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -156,6 +156,16 @@
             'font-size': `${1 - $store.state.currentGridSize / 16}rem`,
           }"
         >
+        <v-tooltip bottom v-if="!isCertain">
+          <template v-slot:activator="{ on, attrs }">
+            <span v-bind="attrs" v-on="on">
+            ❗
+            </span>
+          </template>
+          <span>
+          {{ $tc("component.videoCard.uncertainPlaceholder") }}
+          </span>
+        </v-tooltip>
           {{ title }}
         </div>
         <!-- Channel -->
@@ -379,6 +389,9 @@ export default {
         },
         isPlaceholder() {
             return this.data.type === "placeholder";
+        },
+        isCertain() {
+          return !this.isPlaceholder || this.data.certainty === "certain";
         },
         title() {
             if (this.isPlaceholder) {

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -158,9 +158,18 @@
         >
         <v-tooltip bottom v-if="!isCertain">
           <template v-slot:activator="{ on, attrs }">
-            <span v-bind="attrs" v-on="on">
-            ❗
-            </span>
+            <v-btn
+              icon
+              v-on="on"
+              x-small
+              class="plain-button"
+              width="17"
+              :ripple="false"
+            >
+              <v-icon right size="21" color="amber">
+                {{ icons.mdiClockAlertOutline }}
+              </v-icon>
+            </v-btn>
           </template>
           <span>
           {{ $tc("component.videoCard.uncertainPlaceholder") }}
@@ -887,5 +896,11 @@ export default {
   display: inline-block;
   top: 5px;
   z-index: 1;
+}
+.plain-button:before {
+  display: none
+}
+.plain-button:hover:before {
+  backgroundColor: transparent
 }
 </style>

--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -45,6 +45,12 @@
           {{ video.topic_id }}
         </router-link>
       </span>
+      <span 
+        v-if="!(video.certainty === 'certain')"
+        style="font-size:95%"
+      > <br>
+        {{ $t("component.videoCard.uncertainPlaceholder") }}.
+      </span>
       <slot name="rightTitleAction">
         <v-btn
           id="video-edit-btn"

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -48,6 +48,7 @@ component:
     googleCalendar: Add to Google Calendar
     totalTLs: Total live chat TLs
     tlPresence: Active translator in last 30 mins
+    uncertainPlaceholder: This time is not officially confirmed
     typeScheduledYT: Scheduled Stream
     typeExternalStream: External Stream
     typeEventPlaceholder: Scheduled Event

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -48,7 +48,7 @@ component:
     googleCalendar: Add to Google Calendar
     totalTLs: Total live chat TLs
     tlPresence: Active translator in last 30 mins
-    uncertainPlaceholder: This time is not officially confirmed
+    uncertainPlaceholder: Start time is not officially confirmed, actual start time may vary.
     typeScheduledYT: Scheduled Stream
     typeExternalStream: External Stream
     typeEventPlaceholder: Scheduled Event

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -65,6 +65,7 @@ export {
     mdiFileDocumentMultiple,
     mdiRobot,
     mdiNoteEdit,
+    mdiClockAlertOutline,
 } from "@mdi/js";
 
 export const ytChat = "M20,2H4C2.9,2,2,2.9,2,4v18l4-4h14c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2zM9.9,10.8v3.8h-2v-3.8L5.1,6.6h2.4l1.4,2.2 l1.4-2.2h2.4L9.9,10.8zM18.9,8.6h-2v6h-2v-6h-2v-2h6V8.6z";

--- a/src/views/AddPlaceholderStream.vue
+++ b/src/views/AddPlaceholderStream.vue
@@ -343,6 +343,7 @@ export default {
                         link: "jctkgHBt4b",
                     },
                 },
+                certainty: this.certainty,
                 link: this.sourceUrl,
             };
         },


### PR DESCRIPTION
This makes a placeholder's `Certainty` value useful by making it visible to the user
![brave_TVOTQS0lUK](https://user-images.githubusercontent.com/41271523/211924823-10e6e971-48b4-49f8-846d-9ad28ba157d6.png)

![image](https://user-images.githubusercontent.com/41271523/211924898-51a2f04c-0b63-4b5e-b172-9f1df63899df.png)
