### PR TITLE
New setting watchViewReversed to place chat on the left

### DIFF
--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -243,6 +243,8 @@ views:
     title: Settings
     darkModeLabel: Dark Mode
     darkModeMsg: Changes the theme between light mode and dark mode
+    watchViewReversedLabel: Show Chat on Left
+    watchViewReversedMsg: Display chat to left of screen in watch screen
     redirectModeLabel: Open on Youtube
     redirectModeMsg: >-
       Clicking on video thumbnails will open it in Youtube, clicking the video

--- a/src/store/settings.module.js
+++ b/src/store/settings.module.js
@@ -27,6 +27,7 @@ const initialState = {
     ignoredTopics: [],
     // Valid values: "grid" | "list" | "denseList"
     homeViewMode: "grid",
+    watchViewReversed: false,
 
     // Live TL Window Settings
     liveTlStickBottom: false,
@@ -118,6 +119,7 @@ const mutations = {
         "liveTlHideSpoiler",
         "hidePlaceholder",
         "homeViewMode",
+        "watchViewReversed",
     ]),
     resetState(state) {
         Object.assign(state, initialState);

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -125,6 +125,15 @@
               :prepend-icon="mdiWeatherNight"
             />
             <!-- :messages="$t('views.settings.darkModeMsg')" -->
+            <v-switch
+              v-model="watchViewReversed"
+              class="v-input--reverse v-input--expand"
+              :label="$t('views.settings.watchViewReversedLabel')"
+              hide-details
+              inset
+              :prepend-icon="mdiWeatherNight"
+            />
+            <!-- :messages="$t('views.settings.watchViewReversedMsg')" -->
             <div class="mt-6">
               <v-icon style="margin-right: 9px">
                 {{ mdiPalette }}
@@ -319,6 +328,7 @@ export default {
             "autoplayVideo",
             "scrollMode",
             "defaultOpen",
+            "watchViewReversed",
         ]),
         currentCol() {
             if (this.$vuetify.breakpoint.smAndDown) return 12;

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -12,7 +12,8 @@
       'theater-mode': video.type === 'stream' || $vuetify.breakpoint.mdAndDown,
       'show-chat': showChatWindow,
       'full-height': theaterMode,
-      'show-highlights-bar': showHighlightsBar
+      'show-highlights-bar': showHighlightsBar,
+      'flex-row-reverse': watchViewReversed,
     }"
   >
     <KeyPress
@@ -214,6 +215,7 @@ export default {
     computed: {
         ...mapState("watch", ["video", "isLoading", "hasError"]),
         ...syncState("watch", ["showTL", "showLiveChat", "theaterMode"]),
+        ...syncState("settings", ["watchViewReversed"]),
         chatStatus: {
             get() {
                 return {


### PR DESCRIPTION
This has been a great mode in MultiView. After doing it manually for months, this implements it in `/watch` . Togglable in Settings.

Use case: Have 2 monitors. Left monitor is center, where my focus is, displaying other content. Right monitor to the side has Holodex. Chat on the left places it closer to my center of focus.

![image](https://user-images.githubusercontent.com/110650/211997728-d4b2e4d6-3c41-48ac-b8d6-2eca7d404781.png)
