### PR TITLE
Add `Hide Missing Streams` to video feed settings

### DIFF
--- a/src/components/multiview/VideoSelector.vue
+++ b/src/components/multiview/VideoSelector.vue
@@ -215,6 +215,10 @@ export default {
             default: true,
             type: Boolean,
         },
+        hideMissing: {
+            default: true,
+            type: Boolean,
+        },
     },
     data() {
         return {
@@ -242,6 +246,7 @@ export default {
                 forOrg: this.isRealOrg && this.selectedOrg.name,
                 hideIgnoredTopics: true,
                 hidePlaceholder: this.hidePlaceholders,
+                hideMissing: this.hideMissing,
             };
             const isTwitchPlaceholder = (v) => (v.type === "placeholder" && v.link?.includes("twitch.tv"));
             return this.live.filter((l) => this.filterVideos(l, filterConfig) || (this.hidePlaceholders && isTwitchPlaceholder(l)));

--- a/src/components/setting/VideoListFilters.vue
+++ b/src/components/setting/VideoListFilters.vue
@@ -31,6 +31,14 @@
       :messages="$t('views.settings.hideVideoThumbnailsMsg')"
       hide-details
     />
+    <v-switch
+      v-model="hideMissing"
+      class="v-input--reverse v-input--expand"
+      inset
+      :label="$t('views.settings.hideMissingStreams')"
+      :messages="$t('views.settings.hideVideoThumbnailsMsg')"
+      hide-details
+    />
     <!-- <v-switch
       v-model="hideThumbnail"
       class="v-input--reverse v-input--expand"
@@ -66,6 +74,7 @@ export default {
             "ignoredTopics",
             // "hideThumbnail",
             "hidePlaceholder",
+            "hideMissing",
         ]),
         ignoredTopics: {
             get() {

--- a/src/components/video/ConnectedVideoList.vue
+++ b/src/components/video/ConnectedVideoList.vue
@@ -328,6 +328,7 @@ export default {
                 forOrg: this.isFavPage ? "none" : null,
                 hideCollabs: this.shouldHideCollabs,
                 hidePlaceholder: this.$store.state.settings.hidePlaceholder,
+                hideMissing: this.$store.state.settings.hideMissing,
             };
         },
 

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -128,6 +128,7 @@ export default {
                 hideIgnoredTopics: true,
                 forOrg: "",
                 hidePlaceholder: false,
+                hideMissing: this.$store.state.settings.hideMissing,
                 ...this.filterConfig,
             };
             const filtered = this.videos.filter((v) => this.filterVideos(v, config));

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -123,12 +123,11 @@ export default {
     computed: {
         processedVideos() {
             const config = {
+                ...this.$store.state.settings,
                 ignoreBlock: false,
                 hideCollabs: false,
                 hideIgnoredTopics: true,
                 forOrg: "",
-                hidePlaceholder: false,
-                hideMissing: this.$store.state.settings.hideMissing,
                 ...this.filterConfig,
             };
             const filtered = this.videos.filter((v) => this.filterVideos(v, config));

--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -283,6 +283,7 @@ views:
     hideCollabStreamsLabel: Hide Collab Streams
     hideCollabStreamsMsg: Hide collab streams from your favorites feed
     hidePlaceholderStreams: Hide Placeholder Streams
+    hideMissingStreams: Hide Missing Streams
     ignoredTopicsLabel: Ignored Topics
     ignoredTopicsMsg: Hide videos with these topics from the Home and Favorites pages
     theme: Theme

--- a/src/mixins/filterVideos.js
+++ b/src/mixins/filterVideos.js
@@ -6,6 +6,7 @@ export default {
             hideIgnoredTopics = true,
             forOrg = "",
             hidePlaceholder = false,
+            hideMissing = false,
         }) {
             const blockedChannels = this.$store.getters["settings/blockedChannelIDs"];
             const ignoredTopics = this.$store.getters["settings/ignoredTopics"];
@@ -33,6 +34,10 @@ export default {
 
             if (hidePlaceholder) {
                 keep &&= v.type !== "placeholder";
+            }
+
+            if (hideMissing) {
+                keep &&= v.status !== "missing";
             }
 
             return keep;

--- a/src/store/settings.module.js
+++ b/src/store/settings.module.js
@@ -22,6 +22,7 @@ const initialState = {
     scrollMode: true,
     hideThumbnail: false,
     hidePlaceholder: false,
+    hideMissing: false,
     nameProperty: englishNamePrefs.has(lang) ? "english_name" : "name",
     hideCollabStreams: false,
     ignoredTopics: [],
@@ -117,6 +118,7 @@ const mutations = {
         "liveTlShowSubtitle",
         "liveTlHideSpoiler",
         "hidePlaceholder",
+        "hideMissing",
         "homeViewMode",
     ]),
     resetState(state) {


### PR DESCRIPTION
This adds `Hide Missing Streams` to video feed settings, allowing users to optionally remove cards with `missing` status from their lists.

Most of the time these streams should show up, but in some cases they might bloat feed. For example, setting premiere date to "1 year from now" and deleting waiting room keeps it on channel page 1 the whole time:
![hangingwaitingrooms](https://user-images.githubusercontent.com/74449973/215990007-3467d6da-9b3a-4845-984f-ede0b0706813.png)
