### PR TITLE
Wrap `live-viewers` and `subscriber-count` into spans

### DIFF
--- a/src/components/channel/ChannelInfo.vue
+++ b/src/components/channel/ChannelInfo.vue
@@ -35,9 +35,12 @@
       </span>
     </v-list-item-title>
     <v-list-item-subtitle>
-      <template v-if="!noSubscriberCount">
+      <span
+        v-if="!noSubscriberCount"
+        class="subscriber-count"
+      >
         {{ subscriberCount }}
-      </template>
+      </span>
       <template v-if="includeVideoCount">
         •
         {{ $t("component.channelInfo.videoCount", [channel.video_count]) }}

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -220,7 +220,10 @@
               }}
             </span>
           </template>
-          <template v-else-if="data.status === 'live' && data.live_viewers > 0">
+          <span
+            v-else-if="data.status === 'live' && data.live_viewers > 0"
+            class="live-viewers"
+          >
             •
             {{
               $tc(
@@ -229,7 +232,7 @@
                 [formatCount(data.live_viewers, lang)]
               )
             }}
-          </template>
+          </span>
         </div>
       </div>
       <!-- Vertical dots menu -->

--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -23,7 +23,10 @@
     </v-card-title>
     <v-card-subtitle>
       {{ formattedTime }}
-      <template v-if="video.status === 'live' && liveViewers">
+      <span
+        v-if="video.status === 'live' && liveViewers"
+        class="live-viewers"
+      >
         • {{ $t("component.videoCard.watching", [liveViewers]) }}
         <span
           v-if="liveViewerChange"
@@ -31,7 +34,7 @@
         >
           ({{ (liveViewerChange > 0 ? "+ " : "") + liveViewerChange }})
         </span>
-      </template>
+      </span>
       <span
         v-if="video.topic_id"
         class="mx-1"


### PR DESCRIPTION
Use-case: occasional desire to not bloat vision with pointless numbers and judge content on its own merit.
Wrapping them into spans with classes drastically simplifies it.

Alternatively this can be implemented as option in user settings, if people need it.