### PR TITLE
Improve `waitForElement()`

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -376,19 +376,25 @@ export function checkIOS() {
     );
 }
 
-export function waitForElement(selector) {
-    return new Promise((resolve) => {
-        if (document.querySelector(selector)) {
-            resolve(document.querySelector(selector));
-            return;
+export function waitForElement(selector, parent = document.body, waitTime = 90e3) {
+    return new Promise((resolve, reject) => {
+        const elem = parent.querySelector(selector);
+        if (elem) {
+            return resolve(elem);
         }
+        const timeout = setTimeout(() => {
+            observer.disconnect();
+            return reject(new Error(`${selector} timed out`));
+        }, waitTime);
         const observer = new MutationObserver(() => {
-            if (document.querySelector(selector)) {
-                resolve(document.querySelector(selector));
+            const elem = parent.querySelector(selector);
+            if (elem) {
+                clearTimeout(timeout);
                 observer.disconnect();
+                return resolve(elem);
             }
         });
-        observer.observe(document.body, {
+        observer.observe(parent, {
             childList: true,
             subtree: true,
         });


### PR DESCRIPTION
There are a few issues with `waitForElement` implementation.

1. If the element is never added, the `MutationObserver` just keeps running forever, which is very resource-intensive.
For example, if external resource such as Twitter doesn't load, some pages are waiting for `.twitter-timeline-rendered`. After moving to other pages, the `MutationObserver` keeps running.
2. This function works globally with `document` and `document.body` (which is by the way incorrect as it won't be able to wait for elements in `<head>`). Global `MutationObserver` is costly, especially during page loads, and should be avoided if possible.
3. `querySelector` runs twice on success.

This PR adds optional parameters `parent` and `waitTime` to this function.
`parent` allows to specify the element where we expect to see our `selector` if we know it. Default: `document.body`
`waitTime` allows to specify wait time before the promise rejects with `Error`. Default: 90 seconds.

We can also actually check `MutationRecord`s to avoid calling `querySelector` every time, but it won't give as significant performance boost as specifying `parent` element.