### PR TITLE
Add `Reine` theme

### DIFF
--- a/src/utils/themes.js
+++ b/src/utils/themes.js
@@ -354,5 +354,21 @@ export default [
       },
     },
   },
+  {
+    name: "Reine",
+    id: 22,
+    themes: {
+      dark: {
+        background: "#090909",
+        primary: "#1775fb",
+        secondary: "#51c3a3",
+      },
+      light: {
+        background: "#f9f3f6",
+        primary: "#1c51a3",
+        secondary: "#5fbea3",
+      },
+    },
+  },
 
 ];


### PR DESCRIPTION
This PR adds `Reine` theme.

![holodex-reine-dark](https://user-images.githubusercontent.com/74449973/218402394-82ef68f0-f43c-4f1a-a12d-bb1aa8c68c1f.png)
![holodex-reine-light](https://user-images.githubusercontent.com/74449973/218402409-e6940d3c-0ffa-4a69-83f5-cda53ba4cfc5.png)

Rationale for colors:
`#090909`: dark bg, nuff said
`#f9f3f6`: white bg with a hint of soft peach, referring to slight pinkish accents on hair
`#1775fb`, `#1c51a3`: variations of dodger blue and royal blue; these blueish colors are her main thematical color used in most assets and OG outfit
`#51c3a3`, `#5fbea3`: variations of aquamarine and light sea green, secondary thematical color used in many assets (e.g. ID classroom) and forearm bracelets in OG outfit.

* searchbar close button fix not included but shown for reference