### PR TITLE
Fix invisible close button on search terms in light themes

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -64,7 +64,11 @@
           </v-list-item-content>
 
           <v-list-item-action>
-            <v-icon small color="primary accent-2" @click="deleteChip(selection.item)">
+            <v-icon
+              small
+              :color="$vuetify.theme.dark ? 'primary accent-2' : 'secondary lighten-3'"
+              @click="deleteChip(selection.item)"
+            >
               {{ icons.mdiClose }}
             </v-icon>
           </v-list-item-action>


### PR DESCRIPTION
This sad PR fixes issue on light themes in vue2.

"X" has `primary` color in both themes, so in any light theme it's effectively invisible on `primary` background.
Setting its color to lighter `secondary` makes life brighter.

![holodex-searchclosefix-light](https://user-images.githubusercontent.com/74449973/218404944-f053ebd5-9aa7-4962-9355-0581a94f03e7.png)
