### PR TITLE
fix(i18n): typo in Thai search menu (#670)

### DIFF
--- a/src/locales/th-TH/ui.yml
+++ b/src/locales/th-TH/ui.yml
@@ -207,7 +207,7 @@ views:
     unsupportedQuery: >-
       ขณะนี้ไม่รองรับการค้นหาคลิปตาม <kbd>หัวข้อ</kbd> และ <kbd> ค่าย </kbd> ทำให้ไม่มี<b>คลิป</b>ปรากฏขึ้น
     sortByLabel: เรียงตาม
-    typeDropdownLabel: ปนะเภท
+    typeDropdownLabel: ประเภท
   settings:
     title: การตั้งค่า
     darkModeLabel: โหมดมืด


### PR DESCRIPTION
Correcting typo for issue https://github.com/HolodexNet/Holodex/issues/670

Screenshot of fix:
![image](https://user-images.githubusercontent.com/81057116/219249996-09ea01b9-0aea-42f2-b983-b1a6d48ef848.png)
