### PR TITLE
[vue2 backport] Improve channel/video regexes

### DIFF
--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -67,16 +67,16 @@ export default {
     return axiosInstance.get(`/clips?${q}`);
   },
   searchAutocomplete(query) {
-    const channelId = query.match(CHANNEL_URL_REGEX);
-    const videoId = query.match(VIDEO_URL_REGEX);
+    const channelMatch = query.match(CHANNEL_URL_REGEX);
+    const videoMatch = query.match(VIDEO_URL_REGEX);
 
-    if (channelId && !channelId[0].includes("/c/")) {
-      const q = querystring.stringify({ q: channelId[1] });
+    if (channelMatch) {
+      const q = querystring.stringify({ q: channelMatch.groups.id });
       return axiosInstance.get(`/search/autocomplete?${q}`);
     }
 
-    if (videoId) {
-      return { data: [{ type: "video url", value: `${videoId[5]}` }] };
+    if (videoMatch) {
+      return { data: [{ type: "video url", value: videoMatch.groups.id }] };
     }
 
     const q = querystring.stringify({ q: query });

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -58,11 +58,11 @@ export const ORGS_PREFIX = Object.freeze({
     "All Vtubers": "Vtuber",
 });
 
-export const CHANNEL_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?youtu(?:be\.com\/)(?:channel|c)\/([\w\-\_]*)/i;
+export const CHANNEL_URL_REGEX = /(?:(?:https?:|)\/\/|)(?:www\.|)(?:youtube\.com\/|\/?)channel\/(?<id>[\w-]+)/i;
 
-export const VIDEO_URL_REGEX = /((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be|holodex.net))(\/(?:[\w\-]+\?v=|embed\/|v\/|watch\/)?)([\w\-]+)(\S+)?/i;
+export const VIDEO_URL_REGEX = /(?:(?:https?:|)\/\/|)((?:www|m)\.|)(?<domain>youtube\.com|youtu\.be|holodex\.net)\/(?:[\w-]+\?v=|embed|v|watch|live|)\/?(?<id>[\w-]{11})/i;
 
-export const TWITCH_VIDEO_URL_REGEX = /(?:https:\/\/)?twitch\.tv\/([\w\-_]*)/i;
+export const TWITCH_VIDEO_URL_REGEX = /(?:(?:https?:|)\/\/|)twitch\.tv\/(?<id>[\w-]+)/i;
 
 export const TWITCH_UNLIVE_VIDEO_URL_REGEX = /(?:https:\/\/)?twitch\.tv\/videos\/([\w\-_]*)/i;
 

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -241,14 +241,14 @@ export function videoTemporalComparator(a, b) {
  * @returns {Object}
  */
  export function getVideoIDFromUrl(url) {
-    if (VIDEO_URL_REGEX.test(url)) {
+    {
         const match = url.match(VIDEO_URL_REGEX);
-        if (match && match[5] && match[5].length === 11) {
+        if (match) {
             return {
-                id: match[5],
+                id: match.groups.id,
                 custom: true,
                 channel: {
-                    name: match[5],
+                    name: match.groups.id,
                 },
             };
         }
@@ -265,15 +265,15 @@ export function videoTemporalComparator(a, b) {
         }
     }
     */
-    if (TWITCH_VIDEO_URL_REGEX.test(url)) {
+    {
         const match = url.match(TWITCH_VIDEO_URL_REGEX);
-        if (match && match[1]) {
+        if (match) {
             return {
-                id: match[1],
+                id: match.groups.id,
                 type: "twitch",
                 custom: true,
                 channel: {
-                    name: match[1],
+                    name: match.groups.id,
                 },
             };
         }


### PR DESCRIPTION
Backport of https://github.com/HolodexNet/Holodex/pull/686

In particular, this also enables `/live/` YT links for search bar: 
![regex-staging](https://user-images.githubusercontent.com/74449973/221160548-f03aa51b-1552-4fa9-ac57-988a92e55a24.jpg)
