### PR TITLE
Fix bottom nav bar icon highlighting when using navigation drawer links

### DIFF
--- a/src/components/nav/MainNav.vue
+++ b/src/components/nav/MainNav.vue
@@ -18,7 +18,7 @@
     </NavDrawer>
 
     <!--* nav drawer is for the left --->
-    <BottomNav v-if="isMobile" :pages="pages.filter((page) => !page.collapsible)" :active="!isWatchPage" />
+    <BottomNav v-if="isMobile" :pages="pages.filter((page) => !page.collapsible)" :active="!isWatchPage" :key="$route.path" />
     <!--* bottom bar --->
 
     <v-app-bar


### PR DESCRIPTION
Fixes icons staying highlighted in #688 by making bottom nav bar refresh whenever route path changes.


https://github.com/HolodexNet/Holodex/assets/39130197/d2242d2d-1c53-42d1-8255-728de74c6451

