### PR TITLE
Fix clips block showing when all clips are missing

### DIFF
--- a/src/components/watch/WatchSideBar.vue
+++ b/src/components/watch/WatchSideBar.vue
@@ -134,10 +134,10 @@ export default {
         //     return Object.values(this.related).map(r => r.length).reduce((a, b) => a+b);
         // }
         related() {
-            const clips = (this.video.clips
-                && this.video.clips.filter((x) => this.$store.state.settings.clipLangs.includes(x.lang)))
-                || [];
-            clips.sort(videoTemporalComparator).reverse();
+            const clips = this.video.clips
+                ?.filter?.((x) => x.status !== "missing" && this.$store.state.settings.clipLangs.includes(x.lang))
+                .sort(videoTemporalComparator)
+                .reverse() || [];
             return {
                 simulcasts: this.video.simulcasts || [],
                 clips,


### PR DESCRIPTION
Clips with `missing` status are not filtered out from "related" section. As result, a bogus `Clips` block may appear:
![clipsmissing](https://github.com/HolodexNet/Holodex/assets/74449973/7a502d0d-2afa-4251-a243-2e057ea8c506)
