### PR TITLE
Fix urlencoding in search by topic link

### DIFF
--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -251,11 +251,11 @@ export default {
             const topic = this.video.topic_id;
             const capitalizedTopic = topic[0].toUpperCase() + topic.slice(1);
             const { org } = this.video.channel;
-            let path = `/search?q=type,value,text%0Atopic,${topic},${capitalizedTopic}`;
+            let q = `type,value,text\ntopic,${topic},${capitalizedTopic}`;
             if (org) {
-                path += `%0Aorg,${org},${org}`;
+                q += `\norg,${org},${org}`;
             }
-            return path;
+            return `/search?${new URLSearchParams({ q })}`;
         },
     },
     watch: {


### PR DESCRIPTION
Example: https://holodex.net/watch/timTOtLj-XY
https://holodex.net/search?q=type,value,text%0Atopic,Bread_&_Fred,Bread_&_Fred%0Aorg,Hololive,Hololive -> https://holodex.net/search?q=type,value,text%0Atopic,Bread_%26_Fred,Bread_%26_Fred%0Aorg,Hololive,Hololive