### PR TITLE
List channels hosting favorites in navdrawer

### DIFF
--- a/src/components/nav/NavDrawer.vue
+++ b/src/components/nav/NavDrawer.vue
@@ -99,9 +99,12 @@
           </v-list-item-avatar>
           <ChannelInfo :channel="vid.channel" no-subscriber-count no-group />
           <v-list-item-action-text v-if="vid.id" :key="'liveclock' + vid.id + tick">
-            <span :class="isLive(vid) ? 'ch-live' : 'ch-upcoming'">
+            <div :class="isLive(vid) ? 'ch-live' : 'ch-upcoming'">
+              <v-avatar v-if="vid.host_channel" :size="20">
+                <ChannelImg :channel="vid.host_channel" :size="20" />
+              </v-avatar>
               {{ formatDurationUpcoming(vid.available_at) }}
-            </span>
+            </div>
           </v-list-item-action-text>
         </v-list-item>
       </template>
@@ -216,14 +219,10 @@ export default {
                     });
 
                 // streams featuring favorites who aren't streaming themselves
-                lives
-                    .filter((x) => x.mentions?.length && !existingChs.has(x.channel.id))
-                    .forEach((x) => {
-                        const cause = x.mentions.filter(({ id }) => favoritesSet.has(id) && !existingChs.has(id))
-                        if (cause.length) {
-                            existingChs.set(x.channel.id, { ...x, cause });
-                        }
-                    });
+                lives.forEach((x) => x.mentions
+                    ?.filter(({ id }) => favoritesSet.has(id) && !existingChs.has(id))
+                    .forEach((m) => existingChs.set(m.id, { ...x, channel: m, host_channel: x.channel }))
+                );
 
                 // remainder:
                 const extras = fav

--- a/src/components/nav/NavDrawer.vue
+++ b/src/components/nav/NavDrawer.vue
@@ -205,6 +205,7 @@ export default {
             const fav = this.$store.state.favorites.favorites || [];
             try {
                 const favoritesSet = this.$store.getters["favorites/favoriteChannelIDs"];
+                const blockedSet = this.$store.getters["settings/blockedChannelIDs"];
                 const lives: Array<any> = this.$store.state.favorites.live;
                 const updateNotice = this.$store.state.favorites.lastLiveUpdate;
                 console.debug(`Updating favs: ${updateNotice}`);
@@ -219,10 +220,12 @@ export default {
                     });
 
                 // streams featuring favorites who aren't streaming themselves
-                lives.forEach((x) => x.mentions
-                    ?.filter(({ id }) => favoritesSet.has(id) && !existingChs.has(id))
-                    .forEach((m) => existingChs.set(m.id, { ...x, channel: m, host_channel: x.channel }))
-                );
+                lives
+                    .filter((x) => x.mentions?.length && !blockedSet.has(x.channel.id))
+                    .forEach((x) => x.mentions
+                        .filter(({ id }) => favoritesSet.has(id) && !existingChs.has(id) && !blockedSet.has(id))
+                        .forEach((m) => existingChs.set(m.id, { ...x, channel: m, host_channel: x.channel }))
+                    );
 
                 // remainder:
                 const extras = fav


### PR DESCRIPTION
With this change, favourite channels that don't have ongoing or upcoming streams but are participating elsewhere are marked as having ongoing/upcoming stream with avatar of the host channel.

Example:
![favext](https://github.com/HolodexNet/Holodex/assets/74449973/436c99b8-ac45-46ed-95ab-eba80a592b49)
Here, Watame participates in Miko stream but also plans her own stream in 2h (which has higher priority).
Marine also participates in Miko stream but currently doesn't have anything on her own channel.
Clicking directly on Miko avatar leads on her channel.

This will help to indicate that favourite vtuber has collab or other activity somewhere else, without cluttering in case if they also have something on their own.
Also if host channel is blocked, they won't be shown.