### PR TITLE
Feature: navigation based on history for sub tabs

### DIFF
--- a/src/views/HomeFave.vue
+++ b/src/views/HomeFave.vue
@@ -212,7 +212,7 @@ export default {
                 3: "list",
             };
             this.$router
-                .replace({
+                .push({
                     // set page to 0 if on scroll mode
                     query: preservePage && {
                         ...this.$route.query,

--- a/src/views/HomeFave.vue
+++ b/src/views/HomeFave.vue
@@ -177,6 +177,7 @@ export default {
         console.log("Activated, so adding refresh timer to HomeFav");
         this.changeTab(true);
         this.setAutoRefresh();
+        window.onpopstate = () => { this.init(); };
     },
     deactivated() {
         if (this.refreshTimer) {
@@ -184,6 +185,7 @@ export default {
             clearInterval(this.refreshTimer);
             this.refreshTimer = null;
         }
+        window.onpopstate = () => { };
     },
     beforeDestroy() {
         console.log("Destroying, so deleting the refresh timer in HomeFav");


### PR DESCRIPTION
Fixes #607 

Updated the HomeFave view:

1. When changing tabs, uses `router.push` instead of `router.replace` to ensure that the tab navigation history is saved internally by vue-router
2. Add listener when user presses back button (`onpopstate`) which ensures the tabs are loaded 
  a. And also cleanup listener when leaving page