### PR TITLE
Fix fetch being unauthorized when a token is present.

### DIFF
--- a/packages/react/src/store/auth.ts
+++ b/packages/react/src/store/auth.ts
@@ -1,4 +1,12 @@
 import { atomWithStorage } from "jotai/utils";
 
 export const userAtom = atomWithStorage<User | null>("user", null);
-export const tokenAtom = atomWithStorage<string | null>("token", null);
+export const tokenAtom = atomWithStorage<string | null>(
+  "token",
+  null,
+  undefined,
+  // we need this atom to be populated from localStorage before first use, or
+  // tasks like `createFetchClient` will fail from receiving a null token
+  // see: https://github.com/pmndrs/jotai/discussions/1999
+  { unstable_getOnInit: true },
+);


### PR DESCRIPTION
The PR enables the `getOnInit` option on `tokenAtom` according to https://github.com/pmndrs/jotai/discussions/1999 so it will be populated before first use. Without this measure, other initialization tasks like `createFetchClient` will behave incorrectly from `tokenAtom` being null even when the user is logged in.