### PR TITLE
Match MultiView collab behavior to regular video view

### DIFF
--- a/src/components/multiview/VideoSelector.vue
+++ b/src/components/multiview/VideoSelector.vue
@@ -248,7 +248,7 @@ export default {
                 ignoreBlock: false,
                 // only hide collabs when favorites tab
                 hideCollabs: this.shouldHideCollabs,
-                forOrg: this.isRealOrg && this.selectedOrg.name,
+                forOrg: this.isRealOrg ? this.selectedOrg.name : "none",
                 hideIgnoredTopics: true,
                 hidePlaceholder: this.hidePlaceholder,
                 hideMissing: this.hideMissing,


### PR DESCRIPTION
This addresses the bug where collabs are being shown in MultiView in spite of the collab setting.

It's not the ideal server-side solution, but it at least mirrors the regular view behavior.