### PR TITLE
Including short project description to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Holodex
 
 [![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/RiceCakess/holodex/blob/master/LICENSE)
-[![Discord Chat](https://img.shields.io/discord/796190073271353385.svg)](https://discord.gg/jctkgHBt4b)
+[![Discord](https://img.shields.io/discord/796190073271353385?label=Discord)](https://discord.gg/jctkgHBt4b)
 [![Deploy to Prod](https://github.com/RiceCakess/holoclips/workflows/Deploy%20to%20production/badge.svg)](https://github.com/RiceCakess/holoclips/actions?query=workflow%3A%22Deploy+to+production%22)
 [![Crowdin](https://badges.crowdin.net/holodex/localized.svg)](https://crowdin.com/project/holodex)
 [![Twitter Follow](https://img.shields.io/twitter/follow/holodex?style=social)](https://twitter.com/holodex)
+
+Holodex is a fan-made vtuber platform at https://holodex.net. The website compiles livestreams from these creators onto a single page and encourages users to fall down the vtuber rabbit hole with a multitude of features including multiview, TL filter, clips, music and more.
 
 ![holodex](https://github.com/RiceCakess/Holodex/blob/dev/public/img/intro-promo.jpg)
 


### PR DESCRIPTION
Hello,

I updated the landing page to include the website's link and a short description (borrowing language from the official X/Twitter's bio). I hoped this would make it easier for others to understand what the project is about, especially if they are finding it for the first time through Github.

I also changed the Discord badge's label from "chat" to "Discord" to make it easier to find. 