### PR TITLE
Quote watch page topic search query due to commas

### DIFF
--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -257,7 +257,7 @@ export default {
             const topic = this.video.topic_id;
             const capitalizedTopic = topic[0].toUpperCase() + topic.slice(1);
             const { org } = this.video.channel;
-            let q = `type,value,text\ntopic,${topic},${capitalizedTopic}`;
+            let q = `type,value,text\ntopic,"${topic}","${capitalizedTopic}"`;
             if (org) {
                 q += `\norg,${org},${org}`;
             }


### PR DESCRIPTION
On a video watch page, the topic tag also serves as a link to search for other streams with the same topic. If that topic ID has a comma, then it will cause issues with the search query parameters.

Ideally, we would reuse `json2csv` to handle the encoding, but json2csv before version 5 does not support synchronous evaluation. Upgrading to v5 requires upgrades to the node version and some other packages. Promises as a return value aren't supported either: `[Vue warn]: Invalid prop: type check failed for prop "to". Expected String, Object, got Promise `.

So the simple solution is to just quote the topic IDs. This works for topics with and without commas.