### PR TITLE
Expand user profile dropdown with placeholder on click functions

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
+        "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-context-menu": "^2.2.1",
@@ -2036,6 +2037,32 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.0.tgz",
+      "integrity": "sha512-Q/PbuSMk/vyAd/UoIShVGZ7StHHeRFYU7wXmi5GV+8cLXflZAEpHL/F697H1klrzxKXNtZ97vWiC0q3RKUH8UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5066,11 +5093,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -5975,27 +6002,27 @@
       "dev": true
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -6580,9 +6607,9 @@
       "dev": true
     },
     "node_modules/fast-loops": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
-      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.4.tgz",
+      "integrity": "sha512-8dbd3XWoKCTms18ize6JmQF1SFnnfj5s0B7rRry22EofgMu7B6LKHVh+XfFqFGsqnbH54xgeO83PzpKI+ODhlg=="
     },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
@@ -6621,9 +6648,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -11122,9 +11149,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
+    "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-context-menu": "^2.2.1",

--- a/packages/react/src/components/header/header.tsx
+++ b/packages/react/src/components/header/header.tsx
@@ -16,12 +16,18 @@ import { Logo } from "./Logo";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/shadcn/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
 import { userAtom } from "@/store/auth";
 import { useState } from "react";
+import { UserMenuItem } from "./userMenu/components/UserMenuItem";
+import {
+  CalendarIcon,
+  ExitIcon,
+  GearIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
 interface HeaderProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLElement>,
@@ -105,6 +111,28 @@ export function UserMenu() {
   const user = useAtomValue(userAtom);
   const { logout } = useAuth();
 
+  const mockUserMenuItems = [
+    {
+      key: "accountSettings",
+      value: "Account Settings",
+      fn: () => mockNavigate("accountSettings"),
+      icon: <PersonIcon />,
+    },
+    {
+      key: "settings",
+      value: "Settings",
+      fn: () => mockNavigate("settings"),
+      icon: <GearIcon />,
+    },
+    {
+      key: "iCalFeed",
+      value: "ICal Feed",
+      fn: () => mockNavigate("iCalFeed"),
+      icon: <CalendarIcon />,
+    },
+    { key: "logout", value: "Logout", fn: logout, icon: <ExitIcon /> },
+  ];
+
   if (!user) {
     return (
       <Button asChild>
@@ -122,8 +150,22 @@ export function UserMenu() {
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuItem onClick={() => logout()}>Logout</DropdownMenuItem>
+        {/* user profile */}
+        {mockUserMenuItems.map((item) => {
+          return (
+            <UserMenuItem
+              key={item.key + item.value}
+              item={{ key: item.key, value: item.value, icon: item.icon }}
+              onClick={item.fn}
+              // add specific icon
+            />
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function mockNavigate(destination: string) {
+  console.log(destination);
 }

--- a/packages/react/src/components/header/header.tsx
+++ b/packages/react/src/components/header/header.tsx
@@ -13,21 +13,8 @@ import { Link } from "react-router-dom";
 import { SearchBar } from "./searchbar/components/SearchBar";
 import clsx from "clsx";
 import { Logo } from "./Logo";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/shadcn/ui/dropdown-menu";
-import { useAuth } from "@/hooks/useAuth";
-import { userAtom } from "@/store/auth";
 import { useState } from "react";
-import { UserMenuItem } from "./userMenu/components/UserMenuItem";
-import {
-  CalendarIcon,
-  ExitIcon,
-  GearIcon,
-  PersonIcon,
-} from "@radix-ui/react-icons";
+import { UserMenu } from "./userMenu/components/UserMenu";
 interface HeaderProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLElement>,
@@ -105,67 +92,4 @@ export function Header({ id }: HeaderProps) {
       {!isSearching && <UserMenu />}
     </header>
   );
-}
-export function UserMenu() {
-  const { t } = useTranslation();
-  const user = useAtomValue(userAtom);
-  const { logout } = useAuth();
-
-  const mockUserMenuItems = [
-    {
-      key: "accountSettings",
-      value: "Account Settings",
-      fn: () => mockNavigate("accountSettings"),
-      icon: <PersonIcon />,
-    },
-    {
-      key: "settings",
-      value: "Settings",
-      fn: () => mockNavigate("settings"),
-      icon: <GearIcon />,
-    },
-    {
-      key: "iCalFeed",
-      value: "ICal Feed",
-      fn: () => mockNavigate("iCalFeed"),
-      icon: <CalendarIcon />,
-    },
-    { key: "logout", value: "Logout", fn: logout, icon: <ExitIcon /> },
-  ];
-
-  if (!user) {
-    return (
-      <Button asChild>
-        <Link to="/login">{t("component.mainNav.login")}</Link>
-      </Button>
-    );
-  }
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="mx-2 w-8 shrink-0 overflow-hidden rounded-full">
-        <img
-          src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
-          alt="User avatar"
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        {/* user profile */}
-        {mockUserMenuItems.map((item) => {
-          return (
-            <UserMenuItem
-              key={item.key + item.value}
-              item={{ key: item.key, value: item.value, icon: item.icon }}
-              onClick={item.fn}
-              // add specific icon
-            />
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function mockNavigate(destination: string) {
-  console.log(destination);
 }

--- a/packages/react/src/components/header/userMenu/components/UserMenu.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenu.tsx
@@ -6,18 +6,14 @@ import {
   DropdownMenuContent,
   DropdownMenuSeparator,
 } from "@radix-ui/react-dropdown-menu";
-import {
-  PersonIcon,
-  GearIcon,
-  CalendarIcon,
-  ExitIcon,
-} from "@radix-ui/react-icons";
+import { GearIcon, CalendarIcon, ExitIcon } from "@radix-ui/react-icons";
 import { useAtomValue } from "jotai";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { UserMenuItem } from "./UserMenuItem";
 import { Button } from "@/shadcn/ui/button";
 import { DropdownMenuLabel } from "@/shadcn/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/shadcn/ui/avatar";
 
 export function UserMenu() {
   const { t } = useTranslation();
@@ -25,12 +21,6 @@ export function UserMenu() {
   const { logout } = useAuth();
 
   const mockUserMenuItems = [
-    {
-      key: "accountSettings",
-      value: "Account Settings",
-      fn: () => mockNavigate("accountSettings"),
-      icon: <PersonIcon />,
-    },
     {
       key: "settings",
       value: "Settings",
@@ -64,10 +54,17 @@ export function UserMenu() {
       </DropdownMenuTrigger>
       <DropdownMenuContent className="z-30 bg-base-2">
         {/* user profile */}
-        <div>
-          <div className="p-4">
+        <div className="grid grid-cols-4 grid-rows-3 p-4">
+          <Avatar className="col-start-1 row-span-3 row-start-1 self-center justify-self-center">
+            <AvatarImage
+              src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
+              alt="userIcon"
+            />
+            <AvatarFallback>CN</AvatarFallback>
+          </Avatar>
+          <div className="col-span-3 col-start-2 row-span-2 row-start-1">
             <DropdownMenuLabel>{user.username}</DropdownMenuLabel>
-            <div className=" flex flex-row gap-2 px-2 py-1.5 ">
+            <div className="flex flex-row gap-2 px-2 py-1.5 ">
               <div
                 className={user.google_id ? "text-secondary-11" : "text-base"}
               >
@@ -85,6 +82,10 @@ export function UserMenu() {
               </div>
             </div>
           </div>
+          <DropdownMenuLabel className="col-span-3 col-start-2 row-start-3 capitalize text-base-11">
+            {user.role} : {user.contribution_count}
+            {t("component.mainNav.points")}
+          </DropdownMenuLabel>
         </div>
         <DropdownMenuSeparator />
         {mockUserMenuItems.map((item) => {
@@ -93,7 +94,6 @@ export function UserMenu() {
               key={item.key + item.value}
               item={{ key: item.key, value: item.value, icon: item.icon }}
               onClick={item.fn}
-              // add specific icon
             />
           );
         })}

--- a/packages/react/src/components/header/userMenu/components/UserMenu.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenu.tsx
@@ -1,0 +1,107 @@
+import { useAuth } from "@/hooks/useAuth";
+import { userAtom } from "@/store/auth";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+} from "@radix-ui/react-dropdown-menu";
+import {
+  PersonIcon,
+  GearIcon,
+  CalendarIcon,
+  ExitIcon,
+} from "@radix-ui/react-icons";
+import { useAtomValue } from "jotai";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { UserMenuItem } from "./UserMenuItem";
+import { Button } from "@/shadcn/ui/button";
+import { DropdownMenuLabel } from "@/shadcn/ui/dropdown-menu";
+
+export function UserMenu() {
+  const { t } = useTranslation();
+  const user = useAtomValue(userAtom);
+  const { logout } = useAuth();
+
+  const mockUserMenuItems = [
+    {
+      key: "accountSettings",
+      value: "Account Settings",
+      fn: () => mockNavigate("accountSettings"),
+      icon: <PersonIcon />,
+    },
+    {
+      key: "settings",
+      value: "Settings",
+      fn: () => mockNavigate("settings"),
+      icon: <GearIcon />,
+    },
+    {
+      key: "iCalFeed",
+      value: "ICal Feed",
+      fn: () => mockNavigate("iCalFeed"),
+      icon: <CalendarIcon />,
+    },
+    { key: "logout", value: "Logout", fn: logout, icon: <ExitIcon /> },
+  ];
+
+  if (!user) {
+    return (
+      <Button asChild>
+        <Link to="/login">{t("component.mainNav.login")}</Link>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="z-30 mx-2 w-8 shrink-0 overflow-hidden rounded-full bg-base-2">
+        <img
+          src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
+          alt="User avatar"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="z-30 bg-base-2">
+        {/* user profile */}
+        <div>
+          <div className="p-4">
+            <DropdownMenuLabel>{user.username}</DropdownMenuLabel>
+            <div className=" flex flex-row gap-2 px-2 py-1.5 ">
+              <div
+                className={user.google_id ? "text-secondary-11" : "text-base"}
+              >
+                <div className="i-mdi:google p-1 text-xs" />
+              </div>
+              <div
+                className={user.discord_id ? "text-secondary-11" : "text-base"}
+              >
+                <div className="i-mdi:discord p-1 text-xs" />
+              </div>
+              <div
+                className={user.twitter_id ? "text-secondary-11" : "text-base"}
+              >
+                <div className="i-mdi:twitter p-1 text-xs" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <DropdownMenuSeparator />
+        {mockUserMenuItems.map((item) => {
+          return (
+            <UserMenuItem
+              key={item.key + item.value}
+              item={{ key: item.key, value: item.value, icon: item.icon }}
+              onClick={item.fn}
+              // add specific icon
+            />
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function mockNavigate(destination: string) {
+  console.log(destination);
+}

--- a/packages/react/src/components/header/userMenu/components/UserMenu.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenu.tsx
@@ -24,13 +24,13 @@ export function UserMenu() {
     {
       key: "settings",
       value: "Settings",
-      fn: () => mockNavigate("settings"),
+      fn: () => console.log("settings"),
       icon: <GearIcon />,
     },
     {
       key: "iCalFeed",
       value: "ICal Feed",
-      fn: () => mockNavigate("iCalFeed"),
+      fn: () => console.log("iCalFeed"),
       icon: <CalendarIcon />,
     },
     { key: "logout", value: "Logout", fn: logout, icon: <ExitIcon /> },
@@ -52,7 +52,7 @@ export function UserMenu() {
           alt="User avatar"
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="z-30 bg-base-2">
+      <DropdownMenuContent className="relative right-8 z-30 bg-base-2">
         {/* user profile */}
         <div className="grid grid-cols-4 grid-rows-3 p-4">
           <Avatar className="col-start-1 row-span-3 row-start-1 self-center justify-self-center">
@@ -87,7 +87,7 @@ export function UserMenu() {
             {t("component.mainNav.points")}
           </DropdownMenuLabel>
         </div>
-        <DropdownMenuSeparator />
+        <DropdownMenuSeparator className="border-base" />
         {mockUserMenuItems.map((item) => {
           return (
             <UserMenuItem
@@ -100,8 +100,4 @@ export function UserMenu() {
       </DropdownMenuContent>
     </DropdownMenu>
   );
-}
-
-function mockNavigate(destination: string) {
-  console.log(destination);
 }

--- a/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
@@ -3,12 +3,6 @@ import { DropdownMenuItem } from "@/shadcn/ui/dropdown-menu";
 // import { useTranslation } from "react-i18next";
 import { MenuItem } from "../types";
 
-// interface UserMenuItemProps
-//   extends React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> {
-//   item: QueryItem;
-//   onSelect: (_: string) => void;
-// }
-
 interface UserMenuItemProps {
   item: MenuItem;
   onClick: () => void;

--- a/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
@@ -12,10 +12,12 @@ export function UserMenuItem({ item, onClick }: UserMenuItemProps) {
   return (
     <DropdownMenuItem
       onClick={() => onClick()}
-      className="flex h-full w-64 flex-row gap-2"
+      className="grid h-full w-full grid-cols-4 p-4"
     >
-      <div className="p-4">{item.icon}</div>
-      <div>{item.value}</div>
+      <div className="col-start-1 self-center justify-self-center">
+        {item.icon}
+      </div>
+      <div className="col-span-3 col-start-2 px-2">{item.value}</div>
     </DropdownMenuItem>
   );
 }

--- a/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { DropdownMenuItem } from "@/shadcn/ui/dropdown-menu";
+// import { useTranslation } from "react-i18next";
+import { MenuItem } from "../types";
+
+// interface UserMenuItemProps
+//   extends React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> {
+//   item: QueryItem;
+//   onSelect: (_: string) => void;
+// }
+
+interface UserMenuItemProps {
+  item: MenuItem;
+  onClick: () => void;
+}
+
+export function UserMenuItem({ item, onClick }: UserMenuItemProps) {
+  return (
+    <DropdownMenuItem
+      onClick={() => onClick()}
+      className="flex h-full w-64 flex-row gap-2"
+    >
+      <div className="p-4">{item.icon}</div>
+      <div>{item.value}</div>
+    </DropdownMenuItem>
+  );
+}

--- a/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenuItem.tsx
@@ -12,7 +12,7 @@ export function UserMenuItem({ item, onClick }: UserMenuItemProps) {
   return (
     <DropdownMenuItem
       onClick={() => onClick()}
-      className="grid h-full w-full grid-cols-4 p-4"
+      className="grid h-full w-full cursor-pointer grid-cols-4 p-4"
     >
       <div className="col-start-1 self-center justify-self-center">
         {item.icon}

--- a/packages/react/src/components/header/userMenu/types.ts
+++ b/packages/react/src/components/header/userMenu/types.ts
@@ -1,0 +1,5 @@
+export type MenuItem = {
+  key: string;
+  value: string;
+  icon?: React.JSX.Element;
+};

--- a/packages/react/src/components/header/userMenu/types.ts
+++ b/packages/react/src/components/header/userMenu/types.ts
@@ -1,5 +1,5 @@
 export type MenuItem = {
   key: string;
   value: string;
-  icon?: React.JSX.Element;
+  icon: React.JSX.Element;
 };

--- a/packages/react/src/shadcn/ui/avatar.tsx
+++ b/packages/react/src/shadcn/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }


### PR DESCRIPTION
Hoping this is up to standard - wanted to contribute to the front-end work and started with a smaller feature. Work is mainly done through mimicking the look and feel of the existing Holodex site.

- Account settings is not included as it has been merged into settings page in the React version
- Each drop down item has a placeholder function at the moment. Will work on adding Link to them if this request is accepted