### PR TITLE
Add "Starts" before dates for future streams to differentiate from past streams

### DIFF
--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -68,25 +68,29 @@ export function titleTimeString(available_at, lang ) {
 }
 
 export function formatDistance(time, lang, $t, allowNegative = true, now = dayjs()) {
-    let diff;
     if (!time) return "?";
-    const minutesdiff = now.diff(time, "minutes");
-    if (Math.abs(minutesdiff) < 1) return $t("time.soon");
-    if (!allowNegative && minutesdiff > 0) return $t("time.soon");
+    const minutesDiff = now.diff(time, "minutes");
+    if (Math.abs(minutesDiff) < 1) return $t("time.soon");
+    if (!allowNegative && minutesDiff > 0) return $t("time.soon");
     // if (Math.abs(now.diff(time, "days")) > 60) return localizedDayjs(time, lang).format("ll");
-    if (Math.abs(now.diff(time, "hour")) > 23) {
+    const hourDiff = now.diff(time, "hour");
+    if (hourDiff < -23) {
+        return $t("time.diff_future_date", [
+            localizedDayjs(time, lang).format("l"),
+            localizedDayjs(time, lang).format("LT"),
+        ]);
+    }
+    if (hourDiff > 23) {
         return `${localizedDayjs(time, lang).format("l")} (${localizedDayjs(time, lang).format("LT")})`;
     }
     const timeObj = localizedDayjs(time, lang);
     if (new Date(time) > Date.now()) {
-        diff = $t("time.diff_future_date", [
+        return $t("time.diff_future_date", [
             timeObj.fromNow(),
             timeObj.format(`${timeObj.isTomorrow() ? "ddd " : ""}LT`),
         ]);
-        return diff;
     }
-    diff = $t("time.distance_past_date", [localizedDayjs(time, lang).fromNow()]);
-    return diff;
+    return $t("time.distance_past_date", [localizedDayjs(time, lang).fromNow()]);
 }
 
 export function secondsToHuman(s) {


### PR DESCRIPTION
This change only affects streams starting in more than 23 hours (which display dates instead of relative time), bringing some consistency in how future streams are displayed vs past streams by including the (localized) "Starts" prefix for all future streams instead of only near-future ones.

I _believe_ this also works correctly in other languages without looking too strange, but would like verification from experts on that.

Also slightly cleans up formatDistance.

Screenshots (first video in each has the updated behavior):
<img width="874" alt="Screenshot 2024-09-22 at 4 16 56 AM" src="https://github.com/user-attachments/assets/02f6b227-2f75-45f2-8c3f-d2acce285832">

<img width="881" alt="Screenshot 2024-09-22 at 4 17 33 AM" src="https://github.com/user-attachments/assets/763fbf11-dd5e-463b-a637-927a6d828926">
