### PR TITLE
Adds a Multiview link to the simulcasts panel on video page

### DIFF
--- a/src/locales/en/ui.yml
+++ b/src/locales/en/ui.yml
@@ -87,6 +87,15 @@ component:
   relatedVideo:
     clipsLabel: clips
     simulcastsLabel: simulcasts
+    simulcasts:
+      linkToMultiview:
+        tooltip: Open all Simulcasts in Multiview
+        error:
+          layoutBuildFailure: >-
+            An error occurred while creating the Multiview link.
+            Please file a bug report for this on GitHub or via the Discord.
+          noDefaultLayout: Multiview does not have a layout for {videoCount} videos.
+          noSimulcasts: There are no simulcasts for this video.
     refersLabel: refers
     sourcesLabel: sources
     songsLabel: songs


### PR DESCRIPTION
When a layout is available (`/watch/QIQnwYp3tjY`):
![image](https://github.com/user-attachments/assets/f4bbef7a-56b1-4bba-a8b2-0d41c1496038)
On hover:
![image](https://github.com/user-attachments/assets/a5ffbfc4-f4cf-4001-9ffa-c4ebb1bffd65)

When a layout is not available (`/watch/qRAHAMyDRTQ`):
![image](https://github.com/user-attachments/assets/b60b8e26-6192-4361-baee-c86ccbd26c73)
On hover:
![image](https://github.com/user-attachments/assets/3ae2a67c-fcc4-4d00-a872-4d8afd4ef18b)

Support for auto-generating templates for >16 videos can be added in a future work piece.