### PR TITLE
FIX: WatchSideBar correctly generates content for simulcast link

### DIFF
--- a/src/components/watch/WatchSideBar.vue
+++ b/src/components/watch/WatchSideBar.vue
@@ -243,7 +243,7 @@ export default {
 
             // Fill in blank spaces in the layout with the simulcast videos in order.
             // This is for the case where the default layout already has chat boxes specified in content.
-            const filledContents = layout.map((_, i) => content[i] ?? allSimulcastVideos.shift());
+            const filledContents = Object.fromEntries(layout.map(({ i }) => [i, content[i] ?? allSimulcastVideos.shift()]));
 
             if (allSimulcastVideos.length) {
                 console.warn(`Expected all videos to be placeable in default, but ${allSimulcastVideos.length} were not able to be placed.`);


### PR DESCRIPTION
The current code added in PR #792 uses the fact that `decodeLayout` generates layout item's content indexes based on the item's own index, but this behavior should not be relied upon.

Note that there is no observed change in behavior of the feature, but unblocks changes to the item content indexes in `decodeLayout`.

Relates to #584