### PR TITLE
FIX: correct layout misalignment in WatchSideBar

### DIFF
--- a/src/components/watch/WatchSideBar.vue
+++ b/src/components/watch/WatchSideBar.vue
@@ -2,7 +2,7 @@
   <div>
     <template v-if="video.songcount">
       <span class="lightup d-flex">
-        <a class="d-block text-overline mx-2 my-1" @click="toggleExpansion('songs')">
+        <a class="d-block text-overline mx-2 my-1 pr-2" @click="toggleExpansion('songs')">
           {{ hidden.songs ? "＋" : "－" }} {{ video.songcount }} {{ relationI18N("songs") }}
         </a>
         <v-spacer />
@@ -10,7 +10,7 @@
           icon
           small
           tile
-          class="mr-2"
+          class="mr-2 my-1"
           @click="showDetailed = !showDetailed"
         >
           <v-icon small> {{ mdiTimerOutline }} </v-icon>
@@ -19,7 +19,7 @@
           icon
           small
           tile
-          class="mr-2"
+          class="mr-2 my-1"
           @click="addToMusicPlaylist"
         >
           <v-icon small> {{ icons.mdiMusic }} </v-icon>
@@ -50,7 +50,7 @@
         <div :key="`band${relation}`" class="lightup d-flex">
           <a
             :key="`${relation}-title`"
-            class="d-block text-overline mx-2 my-1"
+            class="d-block text-overline mx-2 my-1 pr-2"
             @click="toggleExpansion(relation)"
           >
             {{ hidden[relation] ? "＋" : "－" }} {{ related[relation].length }} {{ relationI18N(relation) }}
@@ -67,7 +67,7 @@
                   tile
                   :disabled="!simulcastMultiviewLink.ok"
                   small
-                  class="mr-2"
+                  class="mr-2 my-1"
                   :to="simulcastMultiviewLink.url"
                 >
                   <v-icon small>
@@ -88,7 +88,7 @@
             icon
             tile
             small
-            class="mr-2"
+            class="mr-2 my-1"
             @click="addToPlaylist(related[relation])"
           >
             <v-icon small>


### PR DESCRIPTION
Slightly modifies the clickable areas (red) compared to the rest of the header bar (blue) so that they all have consistent vertical spacing.

Before:
![image](https://github.com/user-attachments/assets/1f55b180-7c9e-4979-932f-9f53023f00bf)
After:
![image](https://github.com/user-attachments/assets/09634349-9070-43b1-bd52-cca17f3cfa73)
After without highlighting:
![image](https://github.com/user-attachments/assets/b0a9b580-fab8-4809-836c-25519b16ac9c)

And for the Songs panel:
Before:
![image](https://github.com/user-attachments/assets/92d0b776-1c82-46ba-a54b-f335f32423f0)
After:
![image](https://github.com/user-attachments/assets/dbe447a4-b2dd-44ba-9579-35fc5f8b0ff0)
After without highlighting:
![image](https://github.com/user-attachments/assets/8b70349d-59d0-45c3-83c2-fc3e3760b46b)
