### PR TITLE
MAINT: Add lint check to PRs (dev)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,17 @@
+name: Check PRs
+
+on:
+  pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+    - run: npm ci
+    - run: npm run lint:check

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "vite build --mode prod",
     "preview": "vite preview",
     "lint": "eslint --fix src/",
+    "lint:check": "eslint src/",
     "prepare": "husky install",
     "test": "jest tests"
   },


### PR DESCRIPTION
This will catch cases when Husky hooks fail to setup/run successfully.

Example runs:
Success: https://github.com/meiamsome/Holodex/pull/1
![image](https://github.com/user-attachments/assets/c260687b-606c-4101-a4c0-ca976785688c)

Failure: https://github.com/meiamsome/Holodex/pull/2
![image](https://github.com/user-attachments/assets/f8b33813-0e38-4854-a930-65a46a724bf2)
Details:
![image](https://github.com/user-attachments/assets/31682550-b609-42ce-bf2f-751c8b8e4192)
![image](https://github.com/user-attachments/assets/d720c08c-c604-410f-98fb-d0a8f7a517cf)
