### PR TITLE
MAINT: Add lint check to PRs (next)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,48 @@
+name: Check PRs
+
+on:
+  pull_request
+
+jobs:
+  lint-react:
+    name: Lint React codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+    - run: npm ci
+      working-directory: packages/react
+    - run: npm run lint
+      working-directory: packages/react
+
+  lint-vue3:
+    name: Lint Vue3 codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+    - run: npm ci
+      working-directory: packages/vue3
+    - run: npm run lint
+      working-directory: packages/vue3
+
+  lint:
+    name: Lint codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+    - run: npm ci
+    - run: npm run lint:check

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "vite build --mode prod",
     "preview": "vite preview",
     "lint": "eslint --fix src/",
+    "lint:check": "eslint src/",
     "prepare": "husky install",
     "test": "jest tests"
   },

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -10,6 +10,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "postinstall": "npm run build",
+    "lint": "prettier --check src",
     "lint:fix": "prettier --write src"
   },
   "lint-staged": {


### PR DESCRIPTION
Forward-port of #798 to the `next` branch.

This PR tests against all three working directories in the repo (React, Vue3, base Vue2), although we can obviously not include some of these if necessary (or just delete the files from the branch).

Note that Vue3 codebase currently has lots of linting issues - fix is #800.

These checks don't block merging PRs.