### PR TITLE
FEAT: Split out NotFound page to its own component (next)

### DIFF
--- a/packages/react/src/components/common/NotFound.tsx
+++ b/packages/react/src/components/common/NotFound.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@/shadcn/ui/button";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Helmet>
+        <title>{t("views.notFound.title")} - Holodex</title>
+      </Helmet>
+      <div className="text-center">
+        <h1 className="my-10 text-xl font-bold">{t("views.notFound.title")}</h1>
+        <Button asChild variant="secondary">
+          <Link to="/">{t("views.notFound.back")}</Link>
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/packages/react/src/locales/en/ui.yml
+++ b/packages/react/src/locales/en/ui.yml
@@ -298,7 +298,7 @@ views:
       dateuploadedLatestFirst: Upload date, latest first
       dateuploadedEarliestFirst: Upload date, earliest first
   notFound:
-    title: Content not found
+    title: Content Not Found
     back: Return Home
   search:
     sort:

--- a/packages/react/src/routes/router.tsx
+++ b/packages/react/src/routes/router.tsx
@@ -101,6 +101,7 @@ const Watch = lazy(() =>
 const ResetClientPage = lazy(() =>
   import("./debug").then((module) => ({ default: module.ResetClientPage })),
 );
+const NotFound = lazy(() => import("@/components/common/NotFound"));
 const Playlist = lazy(() => import("./playlist"));
 const Multiview = lazy(() =>
   import("./multiview/multiview").then((module) => ({
@@ -174,6 +175,6 @@ export const routes = (
     <Route path="watch/:id" Component={Watch} />
     <Route path="debug" Component={ResetClientPage} />
     <Route path="debug/run" element={<div>Debug Run</div>} />
-    <Route path="*" element={<div>Not found</div>} />
+    <Route path="*" Component={NotFound} />
   </Route>
 );


### PR DESCRIPTION
Displays as:

![image](https://github.com/user-attachments/assets/2e3221a8-8197-4d83-b43f-cfd71c12282e)

In `components/common` so it can be re-used across pages when the API returns a 404.