### PR TITLE
Add video duration to watch page

### DIFF
--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -25,7 +25,7 @@
       <span :class="'text-' + video.status" :title="absoluteTimeString">
         {{ formattedTime }}
       </span>
-      <span v-if="video.status !== 'live' && video.duration" class="mx-1">
+      <span v-if="video.status !== 'live' && video.duration">
         • {{ formatDuration(video.duration * 1000) }}
       </span>
       <span
@@ -42,7 +42,6 @@
       </span>
       <span
         v-if="video.topic_id"
-        class="mx-1"
         style="text-transform: capitalize"
       >
         • <router-link

--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -25,6 +25,9 @@
       <span :class="'text-' + video.status" :title="absoluteTimeString">
         {{ formattedTime }}
       </span>
+      <span v-if="video.status !== 'live' && video.duration" class="mx-1">
+        • {{ formatDuration(video.duration * 1000) }}
+      </span>
       <span
         v-if="video.status === 'live' && liveViewers"
         class="live-viewers"
@@ -50,7 +53,7 @@
           {{ video.topic_id }}
         </router-link>
       </span>
-      <span 
+      <span
         v-if="video.type === 'placeholder' && !(video.certainty === 'certain')"
         style="font-size:95%"
       > <br>


### PR DESCRIPTION
next.holodex.net/watch has it, and as an editor I find it useful. Since it's easy to implement, I've added it the current version of holodex.

Before:
![2025-02-21 02_41_59 9MZL4YyaBc](https://github.com/user-attachments/assets/fc375bde-720a-4a05-9c59-1e2e1419780e)

After:
![2025-02-21 02_41_39 chrome_VqkEeE64ES](https://github.com/user-attachments/assets/9ea02f41-1ac8-4318-a64e-6f8f1478a0a7)
