### PR TITLE
Fade out active videos in multiview video selector

### DIFF
--- a/src/components/multiview/VideoSelector.vue
+++ b/src/components/multiview/VideoSelector.vue
@@ -80,6 +80,7 @@
             horizontal
             dense
             disable-default-click
+            in-multi-view-selector
             @videoClicked="handleVideoClick"
           />
           <ConnectedVideoList
@@ -91,6 +92,7 @@
             disable-default-click
             dense
             date-portal-name="date-selector-multiview"
+            in-multi-view-selector
             @videoClicked="handleVideoClick"
           />
           <div class="d-block" style="height: 120px" />
@@ -188,8 +190,8 @@ import { mapGetters, mapState } from "vuex";
 import OrgPanelPicker from "@/components/multiview/OrgPanelPicker.vue";
 import filterVideos from "@/mixins/filterVideos";
 import { mdiTwitch } from "@mdi/js";
-import CustomUrlField from "./CustomUrlField.vue";
 import { syncState } from "@/utils/functions";
+import CustomUrlField from "./CustomUrlField.vue";
 
 export default {
     name: "VideoSelector",
@@ -241,7 +243,7 @@ export default {
         ...mapState("playlist", ["active"]),
         ...syncState("settings", [
             "hideCollabStreams",
-            "hidePlaceholder"
+            "hidePlaceholder",
         ]),
         baseFilteredLive() {
             const filterConfig = {

--- a/src/components/video/ConnectedVideoList.vue
+++ b/src/components/video/ConnectedVideoList.vue
@@ -93,6 +93,7 @@
           :filter-config="filterConfig"
           :dense-list="homeViewMode === 'denseList'"
           :horizontal="homeViewMode === 'list'"
+          :in-multi-view-selector="inMultiViewSelector"
           v-bind="$attrs"
           v-on="$listeners"
         />
@@ -107,6 +108,7 @@
             :filter-config="filterConfig"
             :dense-list="homeViewMode === 'denseList'"
             :horizontal="homeViewMode === 'list'"
+            :in-multi-view-selector="inMultiViewSelector"
             v-bind="$attrs"
             v-on="$listeners"
           />
@@ -141,6 +143,7 @@
             v-bind="$attrs"
             :dense-list="homeViewMode === 'denseList'"
             :horizontal="homeViewMode === 'list'"
+            :in-multi-view-selector="inMultiViewSelector"
             v-on="$listeners"
           />
           <!-- only show SkeletonCardList if it's loading -->
@@ -208,6 +211,10 @@ export default {
         datePortalName: {
             type: String,
             default: "",
+        },
+        inMultiViewSelector: {
+            type: Boolean,
+            required: false,
         },
     },
     data() {

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -6,6 +6,7 @@
       'video-card-active': active,
       'video-card-horizontal': horizontal,
       'video-card-list': denseList,
+      'video-card-multiview-active': inMultiViewActiveVideos,
       'flex-column': !horizontal && !denseList,
     }"
     :target="redirectMode ? '_blank' : ''"
@@ -56,8 +57,8 @@
         <!-- Video duration/music indicator (👻❌) -->
         <div v-if="!isPlaceholder" class="d-flex flex-column align-end">
           <!-- Show music icon if songs exist, and song count if there's multiple -->
-          <div 
-            v-if="data.songcount" 
+          <div
+            v-if="data.songcount"
             class="video-duration d-flex align-center"
             :title="songIconTitle"
           >
@@ -360,7 +361,7 @@ export default {
             type: Number,
             default: 1,
         },
-        active: {
+        active: { // TODO: is this always false?
             required: false,
             type: Boolean,
             default: false,
@@ -379,6 +380,10 @@ export default {
             default: null,
         },
         denseList: {
+            type: Boolean,
+            required: false,
+        },
+        inMultiViewSelector: {
             type: Boolean,
             required: false,
         },
@@ -549,6 +554,11 @@ export default {
         },
         twitterPlaceholder() {
             return this.data.link?.includes("/i/spaces/");
+        },
+        inMultiViewActiveVideos() {
+            if (!this.inMultiViewSelector) return false;
+            const { id } = this.data;
+            return this.$store.getters["multiview/activeVideos"].some((video) => video.id === id);
         },
     },
     // created() {
@@ -887,6 +897,12 @@ export default {
   left: -1px;
   opacity: 0.15;
   border-radius: 4px;
+}
+
+.video-card-multiview-active .video-thumbnail,
+.video-card-multiview-active .video-card-title {
+  filter: grayscale(1);
+  opacity: 0.3;
 }
 
 .video-card-subtitle {

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -361,7 +361,7 @@ export default {
             type: Number,
             default: 1,
         },
-        active: { // TODO: is this always false?
+        active: { // TODO: seems always false (see VideoCardList.activeId); 'video-card-active' class is instead toggled via VirtualVideoCardList.activeIndex/checkActive
             required: false,
             type: Boolean,
             default: false,

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -23,6 +23,7 @@
           :disable-default-click="disableDefaultClick"
           :dense-list="denseList"
           :hide-thumbnail="shouldHideThumbnail"
+          :in-multi-view-selector="inMultiViewSelector"
           @videoClicked="handleVideoClick"
         >
           <!-- pass slot to each individual video card -->
@@ -95,7 +96,7 @@ export default {
                 xl: 8,
             }),
         },
-        activeId: {
+        activeId: { // TODO: is this never specified (and thus VideoCard.active always false)?
             required: false,
             type: String,
             default: "",
@@ -118,6 +119,10 @@ export default {
         showComments: {
             type: Boolean,
             default: false,
+        },
+        inMultiViewSelector: {
+            type: Boolean,
+            required: false,
         },
     },
     computed: {

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -96,7 +96,7 @@ export default {
                 xl: 8,
             }),
         },
-        activeId: { // TODO: is this never specified (and thus VideoCard.active always false)?
+        activeId: { // TODO: seems never specified (and thus VideoCard.active always false)
             required: false,
             type: String,
             default: "",


### PR DESCRIPTION
In multidex right now, when using the full video selector (rather than the top bar), it's easy to accidentally add a video that's already added, since there's no visual indicator to distinguish this.

This fades out such already added (active) videos. Example:
![2025-02-20 23_42_32 chrome_8XG9oHS2nL](https://github.com/user-attachments/assets/632f5ce8-8c1a-45bc-b8ee-e975b4bb51e4)

Note: There's an "active" field on VideoCard, but it's apparently always false. Since I don't know it's purpose, I added a new field.