### PR TITLE
Topic autocomplete treats whitespace same as underscore

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -192,7 +192,7 @@ export default {
             this.fromApi = [];
             const entropy = encodeURIComponent(val.trim()).length;
             if (entropy <= 1) return;
-            const formatted = val.trim().replace("#", "");
+            const formatted = val.trim().replace("#", "").replace(/\s+/g, "_");
             this.getAutocomplete(formatted)
                 .then((res) => {
                     let textQueries = [];

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -161,6 +161,7 @@
         <v-autocomplete
           v-model="newTopic"
           :items="topics"
+          :filter="topicFilter"
           inline
           hide-details
           label="Topic (leave empty to unset)"
@@ -399,6 +400,10 @@ export default {
                 this.showSuccess(`Updated Topic to ${this.newTopic}`);
             });
             this.topic = this.newTopic;
+        },
+        topicFilter(_, queryText, itemText) { // same as default filter, just also converting whitespace to underscore
+            return itemText.toString().replace(/\s+/g, "_").toLocaleLowerCase()
+                .indexOf(queryText.toString().replace(/\s+/g, "_").toLocaleLowerCase()) > -1;
         },
     },
 };


### PR DESCRIPTION
In the search bar, autocomplete now handles whitespace when searching for topic by converting whitespace to underscore. This doesn't impact channel or org search, since the backend apparently treats underscore and whitespace the same (just not for topics).
![2025-02-22 14_20_01 chrome_5woDVCtket](https://github.com/user-attachments/assets/48fd1e2d-9758-42b8-bbdf-e98f262040da)

The autocomplete in the video watch card topic editor now also treats whitespace and underscore as the same.
![2025-02-22 14_20_16 chrome_MfoaGMxvMd](https://github.com/user-attachments/assets/102ee1c5-252e-499c-8f14-47e570190de4)
