### PR TITLE
[next] Playlist support

### DIFF
--- a/packages/react/src/components/player/CurrentVideoList.tsx
+++ b/packages/react/src/components/player/CurrentVideoList.tsx
@@ -1,5 +1,3 @@
-import { queueAtom } from "@/store/queue";
-import { useAtom } from "jotai";
 import { VideoCard } from "../video/VideoCard";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/shadcn/ui/button";
@@ -11,14 +9,16 @@ import {
 import { useMemo, useState } from "react";
 import NewPlaylistDialog from "../playlist/NewPlaylistDialog";
 import { WATCH_PAGE_DROPDOWN_BUTTON_STYLE } from "@/shadcn/ui/button.variants";
+import { useCurrentVideoList } from "@/hooks/useCurrentVideoList";
+import { cn } from "@/lib/utils";
 
-export function QueueList({ currentId }: { currentId?: string }) {
+export function CurrentVideoList({ currentId }: { currentId?: string }) {
   const { t } = useTranslation();
-  const [queue, setQueue] = useAtom(queueAtom);
+  const { title, videos, clearList } = useCurrentVideoList();
   // currentIdInQueue:
   const currentIdIdxInQueue = useMemo(() => {
-    return currentId && queue.findIndex(({ id }) => currentId === id) + 1;
-  }, [currentId, queue]);
+    return currentId && videos.findIndex(({ id }) => currentId === id) + 1;
+  }, [currentId, videos]);
   const [open, setOpen] = useState(!!currentIdIdxInQueue);
 
   return (
@@ -34,10 +34,10 @@ export function QueueList({ currentId }: { currentId?: string }) {
           onClick={() => setOpen(!open)}
         >
           <div className={open ? "i-heroicons:minus" : "i-heroicons:plus"} />
-          {t("component.queue.title")}
+          {title}
           <span className="ml-auto text-sm text-base-11">
             {currentIdIdxInQueue ? currentIdIdxInQueue + " / " : ""}
-            {queue.length} items
+            {videos.length} items
           </span>
         </Button>
       </CollapsibleTrigger>
@@ -52,21 +52,27 @@ export function QueueList({ currentId }: { currentId?: string }) {
                     {t("component.playlist.menu.new-playlist")}
                   </Button>
                 }
-                videoIds={queue.map(({ id }) => id)}
+                videoIds={videos.map(({ id }) => id)}
               />
 
-              <Button variant="ghost" onClick={() => setQueue([])}>
-                Clear
-              </Button>
+              {clearList && (
+                <Button variant="ghost" onClick={() => clearList()}>
+                  Clear
+                </Button>
+              )}
             </div>
-            <div className="flex flex-col px-2">
-              {queue.map((video) => (
+            <div className="flex flex-col gap-1">
+              {videos.map((video) => (
                 <VideoCard
                   key={"queue-" + video.id}
                   showDuration={false}
                   showStatus="available_at_only"
                   size="list"
                   video={video}
+                  outerLayerStyle={cn(
+                    "rounded-none px-2",
+                    video.id === currentId && "bg-primary hover:bg-primary",
+                  )}
                 />
               ))}
             </div>

--- a/packages/react/src/components/playlist/IndividualPlaylist.tsx
+++ b/packages/react/src/components/playlist/IndividualPlaylist.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { useToast } from "@/shadcn/ui/use-toast";
 import { Input } from "@/shadcn/ui/input";
 import DeletePlaylistDialog from "@/components/playlist/DeletePlaylistDialog";
+import StartPlaylistLink from "./StartPlaylistLink";
 
 interface Props {
   playlist: Playlist;
@@ -116,8 +117,13 @@ export default function IndividualPlaylist({ playlist }: Props) {
               {playlist.videos.length} Videos
             </TypographyP>
             <div className="mt-4 flex items-center gap-3">
-              <Button size="lg" variant="primary">
-                <span className="i-heroicons:play-solid" /> Play
+              <Button size="lg" variant="primary" asChild>
+                <StartPlaylistLink
+                  firstVideoId={playlist.videos[0].id}
+                  playlistId={playlist.id}
+                >
+                  <span className="i-heroicons:play-solid" /> Play
+                </StartPlaylistLink>
               </Button>
               {userOwnsPlaylist ? (
                 <>

--- a/packages/react/src/components/playlist/IndividualPlaylist.tsx
+++ b/packages/react/src/components/playlist/IndividualPlaylist.tsx
@@ -197,7 +197,13 @@ export default function IndividualPlaylist({ playlist }: Props) {
               </div>
             ) : null}
             <div className="grow">
-              <VideoCard size="sm" video={video} />
+              <VideoCard
+                size="sm"
+                video={{
+                  ...video,
+                  link: `/watch/${video.id}?${new URLSearchParams({ playlist: playlist.id.toString() })}`,
+                }}
+              />
             </div>
           </div>
         );

--- a/packages/react/src/components/playlist/PlaylistEntry.tsx
+++ b/packages/react/src/components/playlist/PlaylistEntry.tsx
@@ -7,6 +7,7 @@ import { userAtom } from "@/store/auth";
 import { Button } from "@/shadcn/ui/button";
 import { VideoThumbnail } from "../video/VideoThumbnail";
 import DeletePlaylistDialog from "@/components/playlist/DeletePlaylistDialog";
+import StartPlaylistLink from "./StartPlaylistLink";
 
 export default function PlaylistEntry({
   video_ids,
@@ -71,8 +72,15 @@ export default function PlaylistEntry({
             dayjs(updated_at).format("LLL")}
         </span>
         <div className="mt-2 flex gap-2 max-md:justify-between">
-          <Button size="sm" variant="primary" className="w-full md:w-20">
-            <span className="i-heroicons:play-solid" />
+          <Button
+            size="sm"
+            variant="primary"
+            className="w-full md:w-20"
+            asChild
+          >
+            <StartPlaylistLink firstVideoId={video_ids[0]} playlistId={id}>
+              <span className="i-heroicons:play-solid" />
+            </StartPlaylistLink>
           </Button>
           <Button
             size="sm"

--- a/packages/react/src/components/playlist/StartPlaylistLink.tsx
+++ b/packages/react/src/components/playlist/StartPlaylistLink.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+import { forwardRef } from "react";
+import { Link } from "react-router-dom";
+
+export const StartPlaylistLink = forwardRef<
+  HTMLAnchorElement,
+  React.HTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    firstVideoId: string | undefined;
+    playlistId: number;
+  }
+>(({ children, firstVideoId, playlistId, className, ...props }, ref) => {
+  return (
+    <Link
+      ref={ref}
+      to={`/watch/${firstVideoId}?${new URLSearchParams({ playlist: playlistId.toString() })}`}
+      className={cn(
+        firstVideoId === undefined && "pointer-events-none opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+});
+
+export default StartPlaylistLink;

--- a/packages/react/src/components/video/VideoCard.tsx
+++ b/packages/react/src/components/video/VideoCard.tsx
@@ -52,6 +52,7 @@ interface VideoCardProps {
   showDuration?: boolean;
   // showing the status of the video object (live now, # watching, or available_at time)
   showStatus?: boolean | "available_at_only";
+  outerLayerStyle?: string;
 }
 
 const LazyVideoCardPlaceholder = React.lazy(
@@ -66,12 +67,11 @@ export function VideoCard({
   onClick,
   showDuration = true,
   showStatus = true,
+  outerLayerStyle,
 }: VideoCardProps) {
   const isTwitchPlaceholder = video.link?.includes("twitch");
   const videoHref =
-    !isTwitchPlaceholder && video.status === "live" && video.link
-      ? video.link
-      : `/watch/${video.id}`;
+    !isTwitchPlaceholder && video.link ? video.link : `/watch/${video.id}`;
   const videoIsPlaceholder = video.type === "placeholder";
   const thumbnailSrc = makeThumbnailUrl(video.id, size, video.thumbnail);
 
@@ -164,7 +164,7 @@ export function VideoCard({
 
   return (
     <div
-      className={videoCardClasses.outerLayer}
+      className={cn(videoCardClasses.outerLayer, outerLayerStyle)}
       onClick={(e) =>
         onClick ? onClick("full", video, e) : goToVideoClickHandler(e)
       }

--- a/packages/react/src/components/video/VideoMenu.tsx
+++ b/packages/react/src/components/video/VideoMenu.tsx
@@ -1,6 +1,7 @@
 import {
   usePlaylistInclude,
-  usePlaylistVideoMutation,
+  usePlaylistVideoAddMutation,
+  usePlaylistVideoDeleteMutation,
 } from "@/services/playlist.service";
 import {
   DropdownMenu,
@@ -31,6 +32,7 @@ import { TLDexLogo } from "../common/TLDexLogo";
 import { userAtom } from "@/store/auth";
 import { videoReportAtom } from "@/store/video";
 import { LazyNewPlaylistDialog } from "./LazyNewPlaylistDialog";
+import { CheckIcon } from "lucide-react";
 
 interface VideoMenuProps {
   video: VideoCardType;
@@ -195,7 +197,8 @@ export function VideoMenu({ children, video, url }: VideoMenuProps) {
 
 function PlaylistMenuItems({ videoId }: { videoId: string }) {
   const { t } = useTranslation();
-  const { mutate } = usePlaylistVideoMutation();
+  const { mutate: addVideo } = usePlaylistVideoAddMutation();
+  const { mutate: deleteVideo } = usePlaylistVideoDeleteMutation();
   const { data, isLoading } = usePlaylistInclude(videoId, { enabled: true });
   const user = useAtomValue(userAtom);
 
@@ -207,9 +210,20 @@ function PlaylistMenuItems({ videoId }: { videoId: string }) {
         </DropdownMenuItem>
       ) : (
         <>
-          {data?.map(({ name, id }) => (
-            <DropdownMenuItem key={id} onClick={() => mutate({ id, videoId })}>
-              {name}
+          {data?.map(({ name, id, contains }) => (
+            <DropdownMenuItem
+              key={id}
+              onClick={() => {
+                !contains
+                  ? addVideo({ id, videoId })
+                  : deleteVideo({ id, videoId });
+              }}
+              onSelect={(event) => event.preventDefault()}
+            >
+              <span>{name}</span>{" "}
+              {contains ? (
+                <CheckIcon className="ml-auto" size={16} />
+              ) : undefined}
             </DropdownMenuItem>
           ))}
           {isLoading && (

--- a/packages/react/src/hooks/useCurrentVideoList.ts
+++ b/packages/react/src/hooks/useCurrentVideoList.ts
@@ -1,0 +1,34 @@
+import { useSuspensePlaylist } from "@/services/playlist.service";
+import { queueAtom } from "@/store/queue";
+import { useAtom } from "jotai";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+
+export function useCurrentVideoList() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const playlistId = searchParams.get("playlist");
+
+  const { data: playlist } =
+    useSuspensePlaylist(playlistId ? parseInt(playlistId || "") : null) || {};
+
+  const [queue, setQueue] = useAtom(queueAtom);
+
+  const videos = useMemo(() => {
+    if (playlist) {
+      const params = new URLSearchParams({ playlist: playlist.id.toString() });
+      return playlist.videos.map((v) => ({
+        ...v,
+        link: `/watch/${v.id}?${params}`,
+      }));
+    }
+    return queue;
+  }, [playlist, queue]);
+
+  return {
+    title: playlist?.name || t("component.queue.title"),
+    videos,
+    clearList: !playlist ? () => setQueue([]) : undefined,
+  };
+}

--- a/packages/react/src/routes/watch.tsx
+++ b/packages/react/src/routes/watch.tsx
@@ -7,9 +7,10 @@ import { Mentions } from "@/components/player/MentionsCard";
 import { PlayerDescription as Description } from "@/components/player/PlayerDescription";
 import { PlayerRecommendations as Recommendations } from "@/components/player/PlayerRecommendations";
 import { VideoStats } from "@/components/player/PlayerStats";
-import { QueueList } from "@/components/player/QueueList";
+import { CurrentVideoList } from "@/components/player/CurrentVideoList";
 import Comments from "@/components/watch/Comments";
 import { useIsLgAndUp } from "@/hooks/useBreakpoint";
+import { useCurrentVideoList } from "@/hooks/useCurrentVideoList";
 import { headerHiddenAtom } from "@/hooks/useFrame";
 import { cn, idToVideoURL } from "@/lib/utils";
 import { useChannel } from "@/services/channel.service";
@@ -21,7 +22,6 @@ import {
   theaterModeAtom,
   tlOpenAtom,
 } from "@/store/player";
-import { queueAtom } from "@/store/queue";
 import { clipLanguageQueryAtom } from "@/store/settings";
 import { currentVideoChannelAtom } from "@/store/video";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -111,11 +111,11 @@ const VideoAsideLists = ({
 }) => {
   const [chatOpen] = useAtom(chatOpenAtom);
   const [tlOpen] = useAtom(tlOpenAtom);
-  const queue = useAtomValue(queueAtom);
+  const { videos } = useCurrentVideoList();
 
   return (
     <div className="hidden w-96 shrink-0 flex-col gap-4 @screen-lg:flex">
-      {!!queue.length && <QueueList currentId={currentVideo?.id} />}
+      {!!videos.length && <CurrentVideoList currentId={currentVideo?.id} />}
       {(currentVideo?.type === "stream" || currentVideo?.status === "live") && (
         <div
           className={cn("overflow-hidden", {


### PR DESCRIPTION
Ticket: #706

Changes:

- Play playlist buttons now navigate to the first video in a playlist
- When `playlist` url param is set to a valid playlist, display the current playlist

[video-playlist-compressed.webm](https://github.com/user-attachments/assets/e64480eb-1579-4e21-a9ca-6f075e0c5078)

- Video playlist options now shows if a video is already in a playlist, and if a video is already in a playlist clicking on it again removes it from the playlist. The mutations also now optimistically update the video-playlist query.

[Screencast from 2025-03-09 17-13-49.webm](https://github.com/user-attachments/assets/301d1e0d-ebed-453b-a0bc-8c06414a45eb)
